### PR TITLE
Add file analysis agent with caching and search tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# organizer
+# File Analysis Agent
+
+Utilities for converting a single local document to Markdown and exposing
+light‑weight inspection tools for other AI agents. The project focuses on
+reusable Markdown conversion, caching and simple line based queries.
+
+## Features
+
+* One time conversion of supported documents to Markdown using [IBM Docling](https://github.com/docling-project).
+* Cache management with atomic writes and metadata sidecars.
+* PydanticAI compatible tools:
+  * `set(path, force=False)` – load and cache a file.
+  * `top(start_line=1, num_lines=50)` – return a slice of lines.
+  * `tail(num_lines=50)` – return the last lines.
+  * `read_full_file()` – return complete Markdown if under token limit.
+  * `find_within_doc(regex_string, flags=None, max_hits=50)` – regex search.
+  * `get_random_lines(start=1, num_lines=20, seed=None)` – deterministic random window.
+  * `get_file_metadata()` – filesystem and cache metadata.
+  * `delete_cache(path)` – remove cached entry for a file.
+
+Plain text files (`.txt`, `.md`, `.json`, `.csv`, etc.) are read directly. Other
+formats (`.docx`, `.pptx`, `.xlsx`, `.pdf`, …) require the `docling` package.
+
+## Configuration
+
+Configuration lives in `file_analysis_agent.config.AgentConfig`. Values can be
+updated at runtime via `file_analysis_agent.config.update_config`.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `cache_dir` | Directory for cached markdown | `~/.file_analysis_cache` |
+| `max_return_chars` | Max characters returned by any tool | `5000` |
+| `regex_default_flags` | Flags applied when none supplied | `"im"` |
+| `token_limit` | Max tokens for `read_full_file` | `4000` |
+| `conversion_timeout` | Seconds allowed for conversion/caching | `45` |
+
+## Examples
+
+```python
+from file_analysis_agent.agent_tools import tools
+
+# Convert and cache
+tools.set("/path/to/document.pdf")
+
+# Inspect
+snippet = tools.top(start_line=10, num_lines=5)
+print(snippet["text"])
+```
+
+## Tests
+
+Run the test suite with:
+
+```bash
+pytest
+```
+
+## Limitations
+
+* Only one file can be analysed at a time.
+* Non text formats require the optional `docling` dependency which is large and
+not installed by default.
+* No network access or remote file retrieval.
+* Outputs are truncated to `max_return_chars`.

--- a/file_analysis_agent/__init__.py
+++ b/file_analysis_agent/__init__.py
@@ -1,0 +1,5 @@
+"""File analysis agent package."""
+from .config import AgentConfig, CONFIG, update_config
+from .agent_tools import tools
+
+__all__ = ["AgentConfig", "CONFIG", "update_config", "tools"]

--- a/file_analysis_agent/agent.py
+++ b/file_analysis_agent/agent.py
@@ -1,0 +1,231 @@
+"""Core analyzer handling file state and tool operations."""
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+import random
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from pathlib import Path
+from typing import List, Optional
+
+import tiktoken
+from pydantic import BaseModel
+
+from .cache import CacheManager, CacheEntry
+from .config import CONFIG
+from .converter import convert_to_markdown
+
+logger = logging.getLogger(__name__)
+
+
+class SliceOutput(BaseModel):
+    start_line: int
+    end_line: int
+    text: str
+
+
+class FindHit(BaseModel):
+    line: int
+    match: str
+    start: int
+    end: int
+    context: str
+
+
+class MetadataOutput(BaseModel):
+    exists: bool
+    path: Optional[str] = None
+    size_megabytes: Optional[float] = None
+    extension: Optional[str] = None
+    mime_type: Optional[str] = None
+    created_time: Optional[float] = None
+    modified_time: Optional[float] = None
+    inode: Optional[int] = None
+    device: Optional[int] = None
+    cache: Optional[dict] = None
+
+
+class FileAnalyzer:
+    """Stateful analyzer used by tools."""
+
+    def __init__(self) -> None:
+        self.cache = CacheManager()
+        self.current_file: Optional[Path] = None
+        self.current_lines: List[str] = []
+        self.cache_entry: Optional[CacheEntry] = None
+        self.last_error: Optional[str] = None
+
+    # Utility
+    def _truncate(self, text: str) -> str:
+        if len(text) <= CONFIG.max_return_chars:
+            return text
+        return text[: CONFIG.max_return_chars] + "\n...[truncated]"
+
+    # Public API
+    def set(self, path: str, force: bool = False) -> dict:
+        """Load and cache a file for subsequent operations."""
+        file_path = Path(path).expanduser().resolve()
+        if not file_path.exists():
+            msg = f"File not found: {file_path}"
+            self.last_error = msg
+            return {"status": "error", "message": msg}
+
+        def _task() -> dict:
+            entry = None if force else self.cache.load(file_path)
+            if entry:
+                markdown = entry.md_path.read_text(encoding="utf-8")
+                self.cache_entry = entry
+            else:
+                markdown = convert_to_markdown(file_path)
+                entry = self.cache.save(file_path, markdown)
+                self.cache_entry = entry
+            self.current_file = file_path
+            self.current_lines = markdown.splitlines()
+            self.last_error = None
+            return {"status": "ok", "message": "file successfully loaded for analysis"}
+
+        with ThreadPoolExecutor(max_workers=1) as ex:
+            future = ex.submit(_task)
+            try:
+                result = future.result(timeout=CONFIG.conversion_timeout)
+                return result
+            except TimeoutError:
+                self.last_error = (
+                    "file could not be loaded within configured time"
+                )
+                return {"status": "error", "message": self.last_error}
+            except Exception as exc:  # pragma: no cover - depends on docling
+                msg = f"conversion failed: {exc}"
+                self.last_error = msg
+                logger.exception("Conversion failed")
+                return {"status": "error", "message": msg}
+
+    def _ensure_loaded(self) -> Optional[dict]:
+        if not self.current_lines:
+            return {"status": "error", "message": self.last_error or "no file loaded"}
+        return None
+
+    def top(self, start_line: int = 1, num_lines: int = 50) -> dict:
+        err = self._ensure_loaded()
+        if err:
+            return err
+        start = max(start_line, 1)
+        end = min(start + num_lines - 1, len(self.current_lines))
+        text = "\n".join(self.current_lines[start - 1 : end])
+        return SliceOutput(start_line=start, end_line=end, text=self._truncate(text)).model_dump()
+
+    def tail(self, num_lines: int = 50) -> dict:
+        err = self._ensure_loaded()
+        if err:
+            return err
+        end = len(self.current_lines)
+        start = max(end - num_lines + 1, 1)
+        text = "\n".join(self.current_lines[start - 1 : end])
+        return SliceOutput(start_line=start, end_line=end, text=self._truncate(text)).model_dump()
+
+    def read_full_file(self) -> dict:
+        err = self._ensure_loaded()
+        if err:
+            return err
+        text = "\n".join(self.current_lines)
+        try:
+            enc = tiktoken.get_encoding(CONFIG.encoding_name)
+            tokens = enc.encode(text)
+        except Exception:
+            # Fallback if tiktoken data is unavailable
+            tokens = text.split()
+        if len(tokens) > CONFIG.token_limit:
+            msg = (
+                "unable to return full file as it exceeds token limit"
+            )
+            return {
+                "status": "error",
+                "message": msg,
+                "text": self._truncate(text),
+            }
+        return {"text": self._truncate(text), "token_count": len(tokens)}
+
+    def find_within_doc(self, regex_string: str, flags: Optional[str] = None, max_hits: int = 50) -> dict:
+        err = self._ensure_loaded()
+        if err:
+            return err
+        flag_value = 0
+        flag_string = flags if flags is not None else CONFIG.regex_default_flags
+        for ch in flag_string:
+            flag_value |= getattr(re, ch, 0)
+        try:
+            pattern = re.compile(regex_string, flag_value)
+        except re.error as exc:
+            return {"status": "error", "message": f"regex compilation error: {exc}"}
+
+        hits: List[FindHit] = []
+        for idx, line in enumerate(self.current_lines, start=1):
+            for match in pattern.finditer(line):
+                hits.append(
+                    FindHit(
+                        line=idx,
+                        match=match.group(),
+                        start=match.start() + 1,
+                        end=match.end() + 1,
+                        context=line,
+                    )
+                )
+                if len(hits) >= max_hits:
+                    break
+            if len(hits) >= max_hits:
+                break
+        return {"hits": [h.model_dump() for h in hits]}
+
+    def get_random_lines(self, start: int = 1, num_lines: int = 20, seed: Optional[int] = None) -> dict:
+        err = self._ensure_loaded()
+        if err:
+            return err
+        rng = random.Random(seed)
+        total_lines = len(self.current_lines)
+        if total_lines <= num_lines:
+            start_line = 1
+            end_line = total_lines
+        else:
+            min_start = max(start, 1)
+            max_start = max(total_lines - num_lines + 1, min_start)
+            start_line = rng.randint(min_start, max_start)
+            end_line = min(start_line + num_lines - 1, total_lines)
+        text = "\n".join(self.current_lines[start_line - 1 : end_line])
+        return SliceOutput(start_line=start_line, end_line=end_line, text=self._truncate(text)).model_dump()
+
+    def get_file_metadata(self) -> dict:
+        if not self.current_file:
+            return {"status": "error", "message": self.last_error or "no file loaded"}
+        p = self.current_file
+        exists = p.exists()
+        data = MetadataOutput(exists=exists, path=str(p))
+        if not exists:
+            return data.model_dump()
+        stat = p.stat()
+        data.size_megabytes = stat.st_size / (1024 * 1024)
+        data.extension = p.suffix
+        data.mime_type = mimetypes.guess_type(p.name)[0]
+        data.created_time = getattr(stat, "st_ctime", None)
+        data.modified_time = getattr(stat, "st_mtime", None)
+        data.inode = getattr(stat, "st_ino", None)
+        data.device = getattr(stat, "st_dev", None)
+        if self.cache_entry:
+            cache_info = {
+                "cache_key": self.cache_entry.key,
+                "cache_path": str(self.cache_entry.md_path),
+                "metadata_path": str(self.cache_entry.meta_path),
+            }
+            data.cache = cache_info
+        return data.model_dump()
+
+    def delete_cache(self, path: str) -> dict:
+        file_path = Path(path).expanduser().resolve()
+        removed = self.cache.delete(file_path)
+        return {"removed": removed}
+
+
+# Global analyzer instance
+analyzer = FileAnalyzer()

--- a/file_analysis_agent/agent_tools/__init__.py
+++ b/file_analysis_agent/agent_tools/__init__.py
@@ -1,0 +1,21 @@
+from .tools import (
+    set,
+    top,
+    tail,
+    read_full_file,
+    find_within_doc,
+    get_random_lines,
+    get_file_metadata,
+    delete_cache,
+)
+
+__all__ = [
+    "set",
+    "top",
+    "tail",
+    "read_full_file",
+    "find_within_doc",
+    "get_random_lines",
+    "get_file_metadata",
+    "delete_cache",
+]

--- a/file_analysis_agent/agent_tools/tools.py
+++ b/file_analysis_agent/agent_tools/tools.py
@@ -1,0 +1,46 @@
+"""PydanticAI-compatible tools wrapping the FileAnalyzer methods."""
+from __future__ import annotations
+
+from typing import Optional
+
+from ..agent import analyzer
+
+
+def set(path: str, force: bool = False) -> dict:
+    """Load a file for analysis, converting and caching markdown as needed."""
+    return analyzer.set(path, force=force)
+
+
+def top(start_line: int = 1, num_lines: int = 50) -> dict:
+    """Return a slice of lines from the cached markdown starting at ``start_line``."""
+    return analyzer.top(start_line=start_line, num_lines=num_lines)
+
+
+def tail(num_lines: int = 50) -> dict:
+    """Return the last ``num_lines`` from the cached markdown."""
+    return analyzer.tail(num_lines=num_lines)
+
+
+def read_full_file() -> dict:
+    """Return the full cached markdown subject to token limits."""
+    return analyzer.read_full_file()
+
+
+def find_within_doc(regex_string: str, flags: Optional[str] = None, max_hits: int = 50) -> dict:
+    """Find regex matches line by line in the cached markdown."""
+    return analyzer.find_within_doc(regex_string, flags=flags, max_hits=max_hits)
+
+
+def get_random_lines(start: int = 1, num_lines: int = 20, seed: Optional[int] = None) -> dict:
+    """Return a random contiguous window of lines from the cached markdown."""
+    return analyzer.get_random_lines(start=start, num_lines=num_lines, seed=seed)
+
+
+def get_file_metadata() -> dict:
+    """Return metadata about the current file and cache entry."""
+    return analyzer.get_file_metadata()
+
+
+def delete_cache(path: str) -> dict:
+    """Remove cached markdown/metadata for ``path`` if present."""
+    return analyzer.delete_cache(path)

--- a/file_analysis_agent/cache.py
+++ b/file_analysis_agent/cache.py
@@ -1,0 +1,110 @@
+"""Cache management for markdown conversions."""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+from .config import CONFIG
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CacheEntry:
+    key: str
+    md_path: Path
+    meta_path: Path
+    metadata: dict
+
+
+class CacheManager:
+    """Manages cached markdown files and metadata sidecars."""
+
+    def __init__(self, cache_dir: Optional[Path] = None) -> None:
+        self.cache_dir = (cache_dir or CONFIG.cache_dir).expanduser().resolve()
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.conversions: int = 0
+        self.last_convert_time: Optional[float] = None
+
+    # Cache key computation
+    def build_key(self, file_path: Path) -> str:
+        """Compute a cache key based on file content and critical metadata."""
+        stat = file_path.stat()
+        h = hashlib.sha256()
+        with open(file_path, 'rb') as f:
+            for chunk in iter(lambda: f.read(8192), b''):
+                h.update(chunk)
+        h.update(str(stat.st_size).encode())
+        h.update(str(int(stat.st_mtime)).encode())
+        return h.hexdigest()
+
+    def _paths_for_key(self, key: str) -> Tuple[Path, Path]:
+        md_path = self.cache_dir / f"{key}.md"
+        meta_path = self.cache_dir / f"{key}.json"
+        return md_path, meta_path
+
+    def load(self, file_path: Path) -> Optional[CacheEntry]:
+        key = self.build_key(file_path)
+        md_path, meta_path = self._paths_for_key(key)
+        if md_path.exists() and meta_path.exists():
+            try:
+                metadata = json.loads(meta_path.read_text())
+            except json.JSONDecodeError:
+                return None
+            logger.info("Cache hit for %s", file_path)
+            return CacheEntry(key, md_path, meta_path, metadata)
+        logger.info("Cache miss for %s", file_path)
+        return None
+
+    def save(self, file_path: Path, markdown: str, key: Optional[str] = None) -> CacheEntry:
+        key = key or self.build_key(file_path)
+        md_path, meta_path = self._paths_for_key(key)
+
+        # Write atomically
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=self.cache_dir, suffix='.md')
+        with os.fdopen(tmp_fd, 'w', encoding='utf-8') as f:
+            f.write(markdown)
+        os.replace(tmp_path, md_path)
+
+        metadata = {
+            "original_path": str(file_path),
+            "size": file_path.stat().st_size,
+            "mtime": file_path.stat().st_mtime,
+            "created": os.path.getctime(file_path),
+            "cache_key": key,
+        }
+
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=self.cache_dir, suffix='.json')
+        with os.fdopen(tmp_fd, 'w', encoding='utf-8') as f:
+            json.dump(metadata, f)
+        os.replace(tmp_path, meta_path)
+
+        self.conversions += 1
+        self.last_convert_time = metadata["created"]
+        logger.info("Cached markdown for %s", file_path)
+        return CacheEntry(key, md_path, meta_path, metadata)
+
+    def delete(self, file_path: Path) -> bool:
+        entry = self.load(file_path)
+        if not entry:
+            return False
+        if entry.md_path.exists():
+            entry.md_path.unlink()
+        if entry.meta_path.exists():
+            entry.meta_path.unlink()
+        logger.info("Deleted cache for %s", file_path)
+        return True
+
+    def cache_size_bytes(self) -> int:
+        total = 0
+        for md_file in self.cache_dir.glob('*.md'):
+            total += md_file.stat().st_size
+        for meta_file in self.cache_dir.glob('*.json'):
+            total += meta_file.stat().st_size
+        return total

--- a/file_analysis_agent/config.py
+++ b/file_analysis_agent/config.py
@@ -1,0 +1,33 @@
+"""Configuration for file analysis agent."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class AgentConfig(BaseModel):
+    """Runtime configuration for the file analysis agent."""
+
+    cache_dir: Path = Field(default=Path.home() / ".file_analysis_cache", description="Directory where cached markdown and metadata are stored")
+    max_return_chars: int = Field(default=5000, description="Maximum characters returned by tools")
+    regex_default_flags: str = Field(default="im", description="Default regex flags used when none are provided")
+    token_limit: int = Field(default=4000, description="Maximum tokens returned by read_full_file before truncation")
+    encoding_name: str = Field(default="cl100k_base", description="Tiktoken encoding name for token counting")
+    conversion_timeout: int = Field(default=45, description="Maximum seconds allowed for conversion/caching step")
+
+
+CONFIG = AgentConfig()
+
+
+def update_config(**kwargs) -> AgentConfig:
+    """Update global configuration values.
+
+    Returns the updated configuration.
+    """
+
+    global CONFIG
+    CONFIG = CONFIG.model_copy(update=kwargs)
+    CONFIG.cache_dir.mkdir(parents=True, exist_ok=True)
+    return CONFIG

--- a/file_analysis_agent/converter.py
+++ b/file_analysis_agent/converter.py
@@ -1,0 +1,43 @@
+"""File conversion utilities using Docling where necessary."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable
+
+from .config import CONFIG
+
+logger = logging.getLogger(__name__)
+
+# Extensions treated as plain text
+TEXT_EXTENSIONS = {
+    ".txt", ".md", ".rst", ".json", ".csv", ".yaml", ".yml", ".ini", ".toml"
+}
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def convert_to_markdown(path: Path) -> str:
+    """Convert a file to markdown using Docling when required."""
+    ext = path.suffix.lower()
+    if ext in TEXT_EXTENSIONS:
+        return _read_text(path)
+
+    try:
+        from docling.document_converter import DocumentConverter
+    except Exception as exc:  # pragma: no cover - depends on optional docling
+        raise RuntimeError(
+            "Docling is required to convert this file. Install 'docling'."
+        ) from exc
+
+    converter = DocumentConverter()
+    result = converter.convert(str(path))
+    # Docling's result object exposes markdown via `.document.export_to_markdown()`
+    try:
+        md = result.document.export_to_markdown()
+    except AttributeError:
+        # Fallback for older versions
+        md = result.markdown
+    return md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "file-analysis-agent"
+version = "0.1.0"
+description = "Tools for converting documents to Markdown and inspecting them"
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic>=2",
+    "tiktoken",
+    "diskcache",
+]
+
+[project.optional-dependencies]
+docling = ["docling"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/tests/data/sample.txt
+++ b/tests/data/sample.txt
@@ -1,0 +1,5 @@
+First line
+Second line
+Third line is here
+Fourth line has keyword
+Fifth line

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,29 @@
+# dummy lines removed by editor bug workaround
+import os
+
+from file_analysis_agent.agent_tools import tools
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), "data", "sample.txt")
+
+
+def test_set_and_top():
+    res = tools.set(DATA_FILE)
+    assert res["status"] == "ok"
+    top = tools.top(start_line=2, num_lines=2)
+    assert top["start_line"] == 2
+    assert "Second line" in top["text"]
+
+
+def test_tail_and_find():
+    tools.set(DATA_FILE)
+    tail = tools.tail(num_lines=2)
+    assert "Fifth line" in tail["text"]
+    hits = tools.find_within_doc("keyword")
+    assert hits["hits"][0]["line"] == 4
+
+
+def test_read_full_file():
+    tools.set(DATA_FILE)
+    res = tools.read_full_file()
+    assert "First line" in res["text"]
+    assert res["token_count"] > 0


### PR DESCRIPTION
## Summary
- add configurable file analysis agent that converts documents to Markdown once and caches results
- expose PydanticAI-friendly tools for reading, searching, and inspecting cached Markdown
- provide tests and documentation

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0c4770fb083208ed0ef31fc75a9b5