### PR TITLE
feat: add json-based configuration and improve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 *.pyc
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,64 +1,98 @@
 # File Analysis Agent
 
-Utilities for converting a single local document to Markdown and exposing
-light‑weight inspection tools for other AI agents. The project focuses on
-reusable Markdown conversion, caching and simple line based queries.
+Utilities for converting a single local document to Markdown and exposing light‑weight
+inspection tools for other AI agents.  The project focuses on reusable Markdown
+conversion, caching and simple line based queries.
 
-## Features
+## Installation
 
-* One time conversion of supported documents to Markdown using [IBM Docling](https://github.com/docling-project).
-* Cache management with atomic writes and metadata sidecars.
-* PydanticAI compatible tools:
-  * `set(path, force=False)` – load and cache a file.
-  * `top(start_line=1, num_lines=50)` – return a slice of lines.
-  * `tail(num_lines=50)` – return the last lines.
-  * `read_full_file()` – return complete Markdown if under token limit.
-  * `find_within_doc(regex_string, flags=None, max_hits=50)` – regex search.
-  * `get_random_lines(start=1, num_lines=20, seed=None)` – deterministic random window.
-  * `get_file_metadata()` – filesystem and cache metadata.
-  * `delete_cache(path)` – remove cached entry for a file.
-
-Plain text files (`.txt`, `.md`, `.json`, `.csv`, etc.) are read directly. Other
-formats (`.docx`, `.pptx`, `.xlsx`, `.pdf`, …) require the `docling` package.
+```bash
+pip install -e .
+# optional dependency for formats like PDF, DOCX, PPTX ...
+pip install -e .[docling]
+```
 
 ## Configuration
 
-Configuration lives in `file_analysis_agent.config.AgentConfig`. Values can be
-updated at runtime via `file_analysis_agent.config.update_config`.
+Default settings live in [`file_analysis_agent/config.json`](file_analysis_agent/config.json):
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `cache_dir` | Directory for cached markdown | `~/.file_analysis_cache` |
-| `max_return_chars` | Max characters returned by any tool | `5000` |
-| `regex_default_flags` | Flags applied when none supplied | `"im"` |
-| `token_limit` | Max tokens for `read_full_file` | `4000` |
-| `conversion_timeout` | Seconds allowed for conversion/caching | `45` |
+```json
+{
+  "cache_dir": "~/.file_analysis_cache",
+  "max_return_chars": 5000,
+  "regex_default_flags": "im",
+  "token_limit": 4000,
+  "encoding_name": "cl100k_base",
+  "conversion_timeout": 45
+}
+```
 
-## Examples
+Edit this file to change the defaults.  Settings can also be tweaked at runtime:
 
 ```python
-from file_analysis_agent.agent_tools import tools
+from file_analysis_agent import update_config
+update_config(max_return_chars=10000)
+```
 
-# Convert and cache
+## Usage
+
+### Tools directly
+
+The tools can be imported and exercised independently of any LLM:
+
+```python
+from file_analysis_agent import tools
+
+# convert and cache
 tools.set("/path/to/document.pdf")
 
-# Inspect
+# inspect
 snippet = tools.top(start_line=10, num_lines=5)
 print(snippet["text"])
 ```
 
-## Tests
+Run the tests for individual tools with:
 
-Run the test suite with:
+```bash
+pytest tests/test_tools.py::test_set_and_top
+```
+
+### Pydantic agent
+
+A ready‑made `pydantic_ai.Agent` exposes the same tools for use in larger
+workflows:
+
+```python
+from file_analysis_agent.agent import agent
+
+agent.run("Use set('/path/to/file.txt')")
+agent.run("Show the top 5 lines")
+```
+
+## Custom runs and cache management
+
+`cache_dir` controls where converted Markdown and metadata are stored.  Remove a
+cached file programmatically with:
+
+```python
+from file_analysis_agent import tools
+
+tools.delete_cache("/path/to/file.txt")
+```
+
+## Testing
+
+Run the full test suite with:
 
 ```bash
 pytest
 ```
 
-## Limitations
+## Design notes
 
-* Only one file can be analysed at a time.
-* Non text formats require the optional `docling` dependency which is large and
-not installed by default.
-* No network access or remote file retrieval.
-* Outputs are truncated to `max_return_chars`.
+* Configuration is validated with Pydantic and stored in a JSON file for easy editing.
+* Markdown conversion uses [IBM Docling](https://github.com/docling-project) when available; plain text formats are read directly.
+* Results are cached with atomic writes and accompanied by metadata sidecars.
+* Tool outputs are truncated to `max_return_chars` and `read_full_file` enforces a
+  token limit to keep responses compact.
+* Only one document is analysed at a time to keep the interface predictable.

--- a/file_analysis_agent/agent_tools/config.py
+++ b/file_analysis_agent/agent_tools/config.py
@@ -1,8 +1,8 @@
 """Configuration for file analysis agent."""
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -10,15 +10,43 @@ from pydantic import BaseModel, Field
 class AgentConfig(BaseModel):
     """Runtime configuration for the file analysis agent."""
 
-    cache_dir: Path = Field(default=Path.home() / ".file_analysis_cache", description="Directory where cached markdown and metadata are stored")
-    max_return_chars: int = Field(default=5000, description="Maximum characters returned by tools")
-    regex_default_flags: str = Field(default="im", description="Default regex flags used when none are provided")
-    token_limit: int = Field(default=4000, description="Maximum tokens returned by read_full_file before truncation")
-    encoding_name: str = Field(default="cl100k_base", description="Tiktoken encoding name for token counting")
-    conversion_timeout: int = Field(default=45, description="Maximum seconds allowed for conversion/caching step")
+    cache_dir: Path = Field(
+        default=Path.home() / ".file_analysis_cache",
+        description="Directory where cached markdown and metadata are stored",
+    )
+    max_return_chars: int = Field(
+        default=5000, description="Maximum characters returned by tools"
+    )
+    regex_default_flags: str = Field(
+        default="im", description="Default regex flags used when none are provided"
+    )
+    token_limit: int = Field(
+        default=4000, description="Maximum tokens returned by read_full_file before truncation"
+    )
+    encoding_name: str = Field(
+        default="cl100k_base", description="Tiktoken encoding name for token counting"
+    )
+    conversion_timeout: int = Field(
+        default=45, description="Maximum seconds allowed for conversion/caching step"
+    )
 
 
-CONFIG = AgentConfig()
+CONFIG_FILE = Path(__file__).resolve().parent.parent / "config.json"
+
+
+def _load_config_from_file() -> AgentConfig:
+    """Load configuration from ``config.json`` if present."""
+    if CONFIG_FILE.exists():
+        data = json.loads(CONFIG_FILE.read_text())
+        cfg = AgentConfig(**data)
+    else:
+        cfg = AgentConfig()
+    cfg.cache_dir = Path(cfg.cache_dir).expanduser()
+    cfg.cache_dir.mkdir(parents=True, exist_ok=True)
+    return cfg
+
+
+CONFIG = _load_config_from_file()
 
 
 def update_config(**kwargs) -> AgentConfig:
@@ -29,5 +57,6 @@ def update_config(**kwargs) -> AgentConfig:
 
     global CONFIG
     CONFIG = CONFIG.model_copy(update=kwargs)
+    CONFIG.cache_dir = Path(CONFIG.cache_dir).expanduser()
     CONFIG.cache_dir.mkdir(parents=True, exist_ok=True)
     return CONFIG

--- a/file_analysis_agent/config.json
+++ b/file_analysis_agent/config.json
@@ -1,0 +1,8 @@
+{
+  "cache_dir": "~/.file_analysis_cache",
+  "max_return_chars": 5000,
+  "regex_default_flags": "im",
+  "token_limit": 4000,
+  "encoding_name": "cl100k_base",
+  "conversion_timeout": 45
+}


### PR DESCRIPTION
## Summary
- load configuration defaults from new `file_analysis_agent/config.json`
- document installation, configuration, usage, and cache management
- ignore generated `*.egg-info` directories

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0e683681c8320bf2a67ac82684ea8