### PR TITLE
Add file organization planner agent with folder tree tool

### DIFF
--- a/file_organization_planner_agent/__init__.py
+++ b/file_organization_planner_agent/__init__.py
@@ -1,0 +1,15 @@
+"""File organization planner agent package."""
+
+from .agent_tools import (
+    find_similar_file_reports,
+    append_organization_notes,
+    get_file_report,
+    target_folder_tree,
+)
+
+__all__ = [
+    "find_similar_file_reports",
+    "append_organization_notes",
+    "get_file_report",
+    "target_folder_tree",
+]

--- a/file_organization_planner_agent/agent.py
+++ b/file_organization_planner_agent/agent.py
@@ -1,0 +1,38 @@
+"""PydanticAI agent exposing file organization planner tools."""
+from __future__ import annotations
+
+from pydantic_ai import Agent
+
+from .agent_tools import tools
+
+agent = Agent(
+    "google-gla:gemini-1.5-flash",
+    system_prompt=(
+        "You are a file organization planning assistant. Use tools to search file reports,"
+        " manage notes, and inspect folder structures."
+    ),
+)
+
+
+@agent.tool_plain
+def find_similar_file_reports(path: str, top_k: int = 10) -> dict:
+    """Find semantically similar file reports for ``path``."""
+    return tools.find_similar_file_reports(path, top_k=top_k)
+
+
+@agent.tool_plain
+def append_organization_notes(ids: list[int], notes: str) -> dict:
+    """Append organization notes to the given file ``ids``."""
+    return tools.append_organization_notes(ids, notes)
+
+
+@agent.tool_plain
+def get_file_report(path: str) -> dict:
+    """Retrieve the stored file report for ``path``."""
+    return tools.get_file_report(path)
+
+
+@agent.tool_plain
+def target_folder_tree(path: str) -> str:
+    """Return a folder tree for ``path`` with a heading."""
+    return tools.target_folder_tree(path)

--- a/file_organization_planner_agent/agent_tools/__init__.py
+++ b/file_organization_planner_agent/agent_tools/__init__.py
@@ -1,0 +1,13 @@
+from .tools import (
+    find_similar_file_reports,
+    append_organization_notes,
+    get_file_report,
+    target_folder_tree,
+)
+
+__all__ = [
+    "find_similar_file_reports",
+    "append_organization_notes",
+    "get_file_report",
+    "target_folder_tree",
+]

--- a/file_organization_planner_agent/agent_tools/tools.py
+++ b/file_organization_planner_agent/agent_tools/tools.py
@@ -1,0 +1,62 @@
+"""Tools for planning file organization."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+from agent_utils.agent_vector_db import AgentVectorDB
+
+_CONFIG_PATH = os.environ.get("FILE_ORGANIZER_CONFIG", "organizer.config.json")
+
+# Global database instance used by the tools
+_db = AgentVectorDB(config_path=_CONFIG_PATH)
+
+def find_similar_file_reports(path: str, top_k: int = 10) -> dict:
+    """Find semantically similar file reports for ``path``."""
+    return _db.find_similar_file_reports(path, top_k=top_k)
+
+def append_organization_notes(ids: Iterable[int], notes: str) -> dict:
+    """Append organization notes for the given file ``ids``."""
+    return _db.append_organization_notes(ids, notes)
+
+def get_file_report(path: str) -> dict:
+    """Retrieve the stored file report for ``path``."""
+    return _db.get_file_report(path)
+
+def target_folder_tree(path: str) -> str:
+    """Return a folder tree for ``path`` with a heading."""
+    p = Path(path).expanduser()
+    lines = [f"Folder Tree for {p}:"]
+    if not p.exists():
+        lines.append("[Path does not exist]")
+        return "\n".join(lines)
+
+    def walk(current: Path, prefix: str = "") -> None:
+        entries = sorted(current.iterdir(), key=lambda e: (not e.is_dir(), e.name.lower()))
+        count = len(entries)
+        for idx, entry in enumerate(entries):
+            connector = "└── " if idx == count - 1 else "├── "
+            if entry.is_dir():
+                lines.append(f"{prefix}{connector}{entry.name}/")
+                extension = "    " if idx == count - 1 else "│   "
+                walk(entry, prefix + extension)
+            else:
+                lines.append(f"{prefix}{connector}{entry.name}")
+
+    if p.is_dir():
+        walk(p)
+    else:
+        lines.append(p.name)
+    return "\n".join(lines)
+
+
+def get_db() -> AgentVectorDB:
+    """Return the global database instance (primarily for tests)."""
+    return _db
+
+
+def set_db(db: AgentVectorDB) -> None:
+    """Replace the global database instance (primarily for tests)."""
+    global _db  # noqa: PLW0603
+    _db = db

--- a/file_organizer_agent.md
+++ b/file_organizer_agent.md
@@ -1,0 +1,13 @@
+# File Organizer Agent
+
+This package provides a simple PydanticAI agent that helps plan how files should be organized.
+It wraps a lightweight SQLite-based vector database from `agent_utils` and exposes a few
+useful tools:
+
+- `find_similar_file_reports(path, top_k=10)` – find semantically similar file reports.
+- `append_organization_notes(ids, notes)` – append notes for one or more file ids.
+- `get_file_report(path)` – fetch the stored file report for a path.
+- `target_folder_tree(path)` – produce a textual folder tree for the given path.
+
+The `agent.py` file illustrates how these tools can be connected to a `pydantic_ai.Agent`
+for interactive use.

--- a/tests/test_planner_tools.py
+++ b/tests/test_planner_tools.py
@@ -1,0 +1,53 @@
+import importlib
+import os
+
+from agent_utils.agent_vector_db import AgentVectorDB
+
+
+class FakeEmbedder:
+    def __init__(self, model_name=None):
+        pass
+
+    def embed(self, texts):
+        vectors = []
+        for t in texts:
+            l = len(t)
+            s = sum(ord(c) for c in t)
+            vectors.append([float(l), float(s % 97), float((l * s) % 53)])
+        return vectors
+
+
+def test_planner_tools(tmp_path, monkeypatch):
+    monkeypatch.setattr("agent_utils.agent_vector_db.TextEmbedding", FakeEmbedder)
+    cfg = tmp_path / "config.json"
+    monkeypatch.setenv("FILE_ORGANIZER_CONFIG", str(cfg))
+
+    # Import tools after patching
+    planner_tools = importlib.reload(importlib.import_module(
+        "file_organization_planner_agent.agent_tools.tools"
+    ))
+
+    db: AgentVectorDB = planner_tools.get_db()
+    base = tmp_path / "base"
+    base.mkdir()
+    db.reset_db(str(base))
+
+    ins1 = db.insert("a.txt")
+    ins2 = db.insert("b.txt")
+    db.set_file_report("a.txt", "hello world")
+    db.set_file_report("b.txt", "hello there")
+    (base / "a.txt").write_text("")
+    (base / "b.txt").write_text("")
+
+    rep = planner_tools.get_file_report("a.txt")
+    assert rep["file_report"] == "hello world"
+
+    notes = planner_tools.append_organization_notes([ins1["id"]], "note1")
+    assert ins1["id"] in notes["updated_ids"]
+
+    sim = planner_tools.find_similar_file_reports("a.txt")
+    assert any(r["path_rel"] == "a.txt" for r in sim["results"])
+
+    tree = planner_tools.target_folder_tree(str(base))
+    assert f"Folder Tree for {base}" in tree
+    assert "a.txt" in tree and "b.txt" in tree


### PR DESCRIPTION
## Summary
- implement `file_organization_planner_agent` exposing vector DB utilities
- add `target_folder_tree` tool to render directory trees
- provide sample agent, README, and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1dc55de8c8320b425710b33ac75fd