### PR TITLE
Add file organization decider agent and shared utilities

### DIFF
--- a/agent_utils/agent_vector_db.py
+++ b/agent_utils/agent_vector_db.py
@@ -367,6 +367,21 @@ class AgentVectorDB:
         return {"ok": True, "path_rel": path_rel, "file_report": row["file_report"]}
 
     @_safe_json
+    def get_organization_notes(self, path_from_base: str) -> dict:
+        path_rel = _norm_rel(path_from_base)
+        row = self.conn.execute(
+            "SELECT organization_notes FROM files WHERE path_rel=?",
+            (path_rel,),
+        ).fetchone()
+        if not row:
+            raise KeyError(f"path not found: {path_rel}")
+        return {
+            "ok": True,
+            "path_rel": path_rel,
+            "organization_notes": row["organization_notes"],
+        }
+
+    @_safe_json
     def find_similar_file_reports(self, path_from_base: str, top_k: int | None = None) -> dict:
         path_rel = _norm_rel(path_from_base)
         row = self.conn.execute("SELECT id, file_report FROM files WHERE path_rel=?", (path_rel,)).fetchone()

--- a/agent_utils/folder_tree.py
+++ b/agent_utils/folder_tree.py
@@ -1,0 +1,31 @@
+"""Utilities for displaying folder trees."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def target_folder_tree(path: str) -> str:
+    """Return a folder tree for ``path`` with a heading."""
+    p = Path(path).expanduser()
+    lines = [f"Folder Tree for {p}:"]
+    if not p.exists():
+        lines.append("[Path does not exist]")
+        return "\n".join(lines)
+
+    def walk(current: Path, prefix: str = "") -> None:
+        entries = sorted(current.iterdir(), key=lambda e: (not e.is_dir(), e.name.lower()))
+        count = len(entries)
+        for idx, entry in enumerate(entries):
+            connector = "└── " if idx == count - 1 else "├── "
+            if entry.is_dir():
+                lines.append(f"{prefix}{connector}{entry.name}/")
+                extension = "    " if idx == count - 1 else "│   "
+                walk(entry, prefix + extension)
+            else:
+                lines.append(f"{prefix}{connector}{entry.name}")
+
+    if p.is_dir():
+        walk(p)
+    else:
+        lines.append(p.name)
+    return "\n".join(lines)

--- a/file_organization_decider_agent/__init__.py
+++ b/file_organization_decider_agent/__init__.py
@@ -1,0 +1,17 @@
+"""File organization decider agent package."""
+
+from .agent_tools import (
+    append_organization_notes,
+    get_file_report,
+    set_planned_destination,
+    get_organization_notes,
+    target_folder_tree,
+)
+
+__all__ = [
+    "append_organization_notes",
+    "get_file_report",
+    "set_planned_destination",
+    "get_organization_notes",
+    "target_folder_tree",
+]

--- a/file_organization_decider_agent/agent.py
+++ b/file_organization_decider_agent/agent.py
@@ -1,0 +1,44 @@
+"""PydanticAI agent exposing file organization decider tools."""
+from __future__ import annotations
+
+from pydantic_ai import Agent
+
+from .agent_tools import tools
+
+agent = Agent(
+    "google-gla:gemini-1.5-flash",
+    system_prompt=(
+        "You are a file organization decision assistant. Use tools to manage notes "
+        "and set planned destinations."
+    ),
+)
+
+
+@agent.tool_plain
+def append_organization_notes(ids: list[int], notes: str) -> dict:
+    """Append organization notes to the given file ``ids``."""
+    return tools.append_organization_notes(ids, notes)
+
+
+@agent.tool_plain
+def get_file_report(path: str) -> dict:
+    """Retrieve the stored file report for ``path``."""
+    return tools.get_file_report(path)
+
+
+@agent.tool_plain
+def set_planned_destination(path: str, planned_dest: str) -> dict:
+    """Set the planned destination for ``path``."""
+    return tools.set_planned_destination(path, planned_dest)
+
+
+@agent.tool_plain
+def get_organization_notes(path: str) -> dict:
+    """Retrieve organization notes for ``path``."""
+    return tools.get_organization_notes(path)
+
+
+@agent.tool_plain
+def target_folder_tree(path: str) -> str:
+    """Return a folder tree for ``path`` with a heading."""
+    return tools.target_folder_tree(path)

--- a/file_organization_decider_agent/agent_tools/__init__.py
+++ b/file_organization_decider_agent/agent_tools/__init__.py
@@ -1,0 +1,15 @@
+from .tools import (
+    append_organization_notes,
+    get_file_report,
+    set_planned_destination,
+    get_organization_notes,
+    target_folder_tree,
+)
+
+__all__ = [
+    "append_organization_notes",
+    "get_file_report",
+    "set_planned_destination",
+    "get_organization_notes",
+    "target_folder_tree",
+]

--- a/file_organization_decider_agent/agent_tools/tools.py
+++ b/file_organization_decider_agent/agent_tools/tools.py
@@ -1,29 +1,41 @@
-"""Tools for planning file organization."""
+"""Tools for deciding file organization."""
 from __future__ import annotations
 
 import os
 from typing import Iterable
 
 from agent_utils.agent_vector_db import AgentVectorDB
-from agent_utils.folder_tree import target_folder_tree
+from agent_utils.folder_tree import target_folder_tree as _target_folder_tree
 
 _CONFIG_PATH = os.environ.get("FILE_ORGANIZER_CONFIG", "organizer.config.json")
 
 # Global database instance used by the tools
 _db = AgentVectorDB(config_path=_CONFIG_PATH)
 
-def find_similar_file_reports(path: str, top_k: int = 10) -> dict:
-    """Find semantically similar file reports for ``path``."""
-    return _db.find_similar_file_reports(path, top_k=top_k)
 
 def append_organization_notes(ids: Iterable[int], notes: str) -> dict:
     """Append organization notes for the given file ``ids``."""
     return _db.append_organization_notes(ids, notes)
 
+
 def get_file_report(path: str) -> dict:
     """Retrieve the stored file report for ``path``."""
     return _db.get_file_report(path)
 
+
+def set_planned_destination(path: str, planned_dest: str) -> dict:
+    """Set the planned destination for ``path``."""
+    return _db.set_planned_destination(path, planned_dest)
+
+
+def get_organization_notes(path: str) -> dict:
+    """Retrieve the organization notes for ``path``."""
+    return _db.get_organization_notes(path)
+
+
+def target_folder_tree(path: str) -> str:
+    """Return a folder tree for ``path`` with a heading."""
+    return _target_folder_tree(path)
 
 
 def get_db() -> AgentVectorDB:
@@ -35,3 +47,4 @@ def set_db(db: AgentVectorDB) -> None:
     """Replace the global database instance (primarily for tests)."""
     global _db  # noqa: PLW0603
     _db = db
+

--- a/tests/test_agent_vector_db.py
+++ b/tests/test_agent_vector_db.py
@@ -33,6 +33,7 @@ def test_agent_vector_db(tmp_path, monkeypatch):
 
     notes_res = db.append_organization_notes([ins1["id"]], "note1")
     assert ins1["id"] in notes_res["updated_ids"]
+    assert db.get_organization_notes("file1.txt")["organization_notes"].startswith("note1")
 
     db.set_planned_destination("file1.txt", "dest/a")
     db.set_final_destination("file1.txt", "final/a")

--- a/tests/test_decider_tools.py
+++ b/tests/test_decider_tools.py
@@ -1,0 +1,55 @@
+import importlib
+import importlib
+import os
+
+from agent_utils.agent_vector_db import AgentVectorDB
+
+
+class FakeEmbedder:
+    def __init__(self, model_name=None):
+        pass
+
+    def embed(self, texts):
+        vectors = []
+        for t in texts:
+            l = len(t)
+            s = sum(ord(c) for c in t)
+            vectors.append([float(l), float(s % 97), float((l * s) % 53)])
+        return vectors
+
+
+def test_decider_tools(tmp_path, monkeypatch):
+    monkeypatch.setattr("agent_utils.agent_vector_db.TextEmbedding", FakeEmbedder)
+    cfg = tmp_path / "config.json"
+    monkeypatch.setenv("FILE_ORGANIZER_CONFIG", str(cfg))
+
+    decider_tools = importlib.reload(importlib.import_module(
+        "file_organization_decider_agent.agent_tools.tools"
+    ))
+
+    db: AgentVectorDB = decider_tools.get_db()
+    base = tmp_path / "base"
+    base.mkdir()
+    db.reset_db(str(base))
+
+    ins1 = db.insert("a.txt")
+    ins2 = db.insert("b.txt")
+    db.set_file_report("a.txt", "hello world")
+    (base / "a.txt").write_text("")
+    (base / "b.txt").write_text("")
+
+    notes = decider_tools.append_organization_notes([ins1["id"]], "note1")
+    assert ins1["id"] in notes["updated_ids"]
+
+    rep = decider_tools.get_file_report("a.txt")
+    assert rep["file_report"] == "hello world"
+
+    org = decider_tools.get_organization_notes("a.txt")
+    assert "note1" in org["organization_notes"]
+
+    decider_tools.set_planned_destination("a.txt", "dest/a")
+    row = db.conn.execute("SELECT planned_dest FROM files WHERE path_rel='a.txt'").fetchone()
+    assert row["planned_dest"] == "dest/a"
+
+    tree = decider_tools.target_folder_tree(str(base))
+    assert "a.txt" in tree and "b.txt" in tree


### PR DESCRIPTION
## Summary
- expose folder tree generation as a reusable utility and update planner tools to use it
- add `get_organization_notes` plus related tooling through a new file_organization_decider_agent
- provide example PydanticAI decider agent and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1e4d015748320bce18cda86c556df