### PR TITLE
Add module docstring for decider agent tools

### DIFF
--- a/file_organization_decider_agent/agent_tools/__init__.py
+++ b/file_organization_decider_agent/agent_tools/__init__.py
@@ -1,3 +1,10 @@
+"""Convenience exports for the decider agent tools.
+
+This module re-exports the helper functions used by the
+``file_organization_decider_agent``.  Having them available at the package
+level provides a compact API for other modules.
+"""
+
 from .tools import (
     append_organization_notes,
     get_file_report,

--- a/file_organization_decider_agent/agent_tools/tools.py
+++ b/file_organization_decider_agent/agent_tools/tools.py
@@ -45,6 +45,5 @@ def get_db() -> AgentVectorDB:
 
 def set_db(db: AgentVectorDB) -> None:
     """Replace the global database instance (primarily for tests)."""
-    global _db  # noqa: PLW0603
+    global _db  # pylint: disable=global-statement
     _db = db
-


### PR DESCRIPTION
## Summary
- add comprehensive module docstring for file_organization_decider_agent.agent_tools
- silence global-statement warning and tidy file formatting

## Testing
- `pylint file_organization_decider_agent/agent_tools`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9ca7e152c8320910b1e1d0f994971