### PR TITLE
refactor file analysis agent configuration and interface

### DIFF
--- a/file_analysis_agent/config.json
+++ b/file_analysis_agent/config.json
@@ -1,4 +1,6 @@
 {
+  "api_key": "",
+  "model": "gpt-5-nano",
   "cache_dir": "~/.file_analysis_cache",
   "max_return_chars": 5000,
   "regex_default_flags": "im",


### PR DESCRIPTION
## Summary
- refactor file analysis agent to load API key and model from config.json
- provide helper to build agent and expose ask_file_analysis_agent function for reuse
- clean up debug output and rename load_file tool

## Testing
- `pylint file_analysis_agent`
- `pytest` *(fails: TypeError: 'list' object is not an iterator)*

------
https://chatgpt.com/codex/tasks/task_e_68ab55edf060832084011dd88c8f521c