### PR TITLE
Add file analysis loop to FolderMate

### DIFF
--- a/agent_utils/agent_vector_db.py
+++ b/agent_utils/agent_vector_db.py
@@ -94,7 +94,8 @@ class AgentVectorDB:
 
         self._prefix = "passage: "
         # embed() returns a generator; take the first vector to determine dimension
-        probe_vec = next(self.embedder.embed([self._prefix + "probe"]))
+        probe_iter = self.embedder.embed([self._prefix + "probe"])
+        probe_vec = next(iter(probe_iter))
         self._dim = int(len(probe_vec))
 
         self._ensure_schema()
@@ -437,5 +438,6 @@ class AgentVectorDB:
 
     def _embed_doc(self, text: str) -> np.ndarray:
         # embed() yields a generator of vectors; take the first and return float32 ndarray
-        vec = next(self.embedder.embed([self._prefix + text]))
+        vec_iter = self.embedder.embed([self._prefix + text])
+        vec = next(iter(vec_iter))
         return np.asarray(vec, dtype=np.float32)


### PR DESCRIPTION
## Summary
- trigger file analysis for missing reports via new `_analyze_pending_files` helper
- support analyze action in API and store analysis in vector DB
- make AgentVectorDB resilient to list-based embedder output

## Testing
- `pytest -q`
- `pylint --disable=C0116 foldermate agent_utils`

------
https://chatgpt.com/codex/tasks/task_e_68ab58dd45748320bcecf326c897ea62