### PR TITLE
Show analysis progress in UI

### DIFF
--- a/foldermate/app.py
+++ b/foldermate/app.py
@@ -186,6 +186,8 @@ def _analyze_pending_files(base_dir: str) -> None:
         if not path_rel:
             break
         abs_path = os.path.join(base_dir_abs, path_rel)
+        db.set_file_report(path_rel, "processing...")
+        runstate.status_text = f"Analyzing {path_rel}"
         report = ask_file_analysis_agent(abs_path)
         db.set_file_report(path_rel, report)
 

--- a/foldermate/static/index.html
+++ b/foldermate/static/index.html
@@ -194,6 +194,7 @@
       rows: [],
       _planTargetId: null,
       _clickTimers: {},
+      _refreshLoopRunning: false,
     };
 
     // --- Helpers ---
@@ -265,6 +266,7 @@
           el.disabled = true; el.classList.add('disabled'); el.classList.remove('active');
         }
       });
+      if(name){ refreshLoop(); }
     }
 
     // --- API ---
@@ -313,6 +315,19 @@
         state.rows = d.rows;
         renderRows();
       }catch(err){console.error(err);}
+    }
+
+    async function refreshLoop(){
+      if(state._refreshLoopRunning) return;
+      state._refreshLoopRunning = true;
+      try{
+        while(state.currentAction){
+          await Promise.all([loadStatus(), loadRows()]);
+          await new Promise(r=>setTimeout(r, 1000));
+        }
+      }finally{
+        state._refreshLoopRunning = false;
+      }
     }
 
     async function fetchReport(id){


### PR DESCRIPTION
## Summary
- Flag files as "processing..." before analysis and update status text
- Add refresh loop to poll status and rows while actions run

## Testing
- `pylint foldermate/app.py` *(fails: score 7.22, pre-existing issues)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab7149745c8320ba707d5a2820b479