### PR TITLE
Add target destination and instruction settings

### DIFF
--- a/foldermate/static/index.html
+++ b/foldermate/static/index.html
@@ -122,6 +122,20 @@
           </div>
         </div>
         <div class="row">
+          <label for="targetPicker">Target path (organized files destination)</label>
+          <input id="targetPath" type="text" placeholder="e.g. C:/organized" />
+          <div>
+            <label class="mono" style="display:none" for="targetPicker">Folder picker</label>
+            <input id="targetPicker" type="file" webkitdirectory directory multiple style="display:none" />
+            <button class="ghost" id="browseTargetBtn">Browse…</button>
+          </div>
+        </div>
+        <div class="row" style="align-items:flex-start">
+          <label for="instructionsBox" style="margin-top:4px">Folder organization instructions/guidelines</label>
+          <textarea id="instructionsBox" rows="10" placeholder="e.g. PDFs to /docs; images to /photos"></textarea>
+          <div></div>
+        </div>
+        <div class="row">
           <label>Recurse subfolders</label>
           <input id="chkRecursive" type="checkbox" checked />
           <div></div>
@@ -187,6 +201,8 @@
     // --- State ---
     const state = {
       basePath: '',
+      targetPath: '',
+      instructions: '',
       recursive: true,
       dontDelete: true,
       status: 'Pending user input',
@@ -205,6 +221,8 @@
     function renderBase(){
       $('#basePathChip').textContent = state.basePath || '(not set)';
       $('#folderPath').value = state.basePath;
+      $('#targetPath').value = state.targetPath;
+      $('#instructionsBox').value = state.instructions;
       $('#chkRecursive').checked = state.recursive;
       $('#chkDontDelete').checked = state.dontDelete;
     }
@@ -280,6 +298,8 @@
       try{
         const d = await fetchJSON('/api/config');
         state.basePath = d.base_dir || '';
+        state.targetPath = d.config?.target_dir || '';
+        state.instructions = d.config?.instructions || '';
         state.recursive = d.config?.recursive ?? true;
         state.dontDelete = d.config?.dont_delete ?? true;
         renderBase();
@@ -293,6 +313,8 @@
           headers:{'Content-Type':'application/json'},
           body:JSON.stringify({
             base_dir: state.basePath || undefined,
+            target_dir: state.targetPath || undefined,
+            instructions: state.instructions || undefined,
             recursive: state.recursive,
             dont_delete: state.dontDelete
           })
@@ -404,6 +426,15 @@
         state.basePath = $('#folderPath').value || base; renderBase(); toast('Folder selected'); saveConfig();
       }
     });
+    $('#browseTargetBtn').addEventListener('click', ()=> $('#targetPicker').click());
+    $('#targetPicker').addEventListener('change', (e)=>{
+      const files = Array.from(e.target.files||[]);
+      if(files.length){
+        const p = files[0].webkitRelativePath || files[0].name;
+        const base = p.split('/')[0];
+        state.targetPath = $('#targetPath').value || base; renderBase(); toast('Target folder selected'); saveConfig();
+      }
+    });
     $('#folderPickerPlan').addEventListener('change', (e)=>{
       const files = Array.from(e.target.files||[]);
       if(!files.length || state._planTargetId==null) return;
@@ -424,6 +455,8 @@
     });
 
     $('#folderPath').addEventListener('change', async e=>{ state.basePath = e.target.value.trim(); renderBase(); await saveConfig(); })
+    $('#targetPath').addEventListener('change', async e=>{ state.targetPath = e.target.value.trim(); renderBase(); await saveConfig(); })
+    $('#instructionsBox').addEventListener('change', async e=>{ state.instructions = e.target.value; renderBase(); await saveConfig(); })
     $('#chkRecursive').addEventListener('change', async e=>{ state.recursive = e.target.checked; await saveConfig(); })
     $('#chkDontDelete').addEventListener('change', async e=>{ state.dontDelete = e.target.checked; await saveConfig(); })
 

--- a/organizer.config.json
+++ b/organizer.config.json
@@ -1,6 +1,8 @@
 {
   "db_path": "organizer.sqlite",
   "base_dir": "D:\\_dev",
+  "target_dir": "D:\\_organized",
+  "instructions": "",
   "embedding_model": "BAAI/bge-small-en-v1.5",
   "search": {
     "top_k": 10,

--- a/tests/test_config_persistence.py
+++ b/tests/test_config_persistence.py
@@ -1,0 +1,70 @@
+"""Tests for config persistence and reset behaviour."""
+
+import importlib
+from fastapi.testclient import TestClient  # pylint: disable=import-error
+
+
+class FakeEmbedder:  # pylint: disable=too-few-public-methods
+    """Minimal fake embedder for tests."""
+
+    def __init__(self, model_name: str | None = None) -> None:
+        """Ignore the model name."""
+
+        _ = model_name  # unused
+
+    def embed(self, texts):
+        """Return zero vectors matching input length."""
+
+        return [[0.0]] * len(list(texts))
+
+
+def test_config_persist(tmp_path, monkeypatch):
+    """Ensure config values persist in SQLite and reset clears them."""
+
+    monkeypatch.setattr("agent_utils.agent_vector_db.TextEmbedding", FakeEmbedder)
+
+    import agent_utils.agent_vector_db as avdb  # pylint: disable=import-outside-toplevel
+
+    orig_connect = avdb.sqlite3.connect
+
+    def _connect(*args, **kwargs):
+        kwargs.setdefault("check_same_thread", False)
+        return orig_connect(*args, **kwargs)
+
+    monkeypatch.setattr(avdb.sqlite3, "connect", _connect)
+
+    import foldermate.app as app_module  # pylint: disable=import-outside-toplevel
+    importlib.reload(app_module)
+
+    db_path = tmp_path / "config.json"
+    new_db = app_module.AgentVectorDB(config_path=str(db_path))
+    base = tmp_path / "base"
+    base.mkdir()
+    new_db.reset_db(str(base))
+    monkeypatch.setattr(app_module, "db", new_db)
+
+    client = TestClient(app_module.app)
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    instr = "Keep PDFs in docs"
+    resp = client.put(
+        "/api/config",
+        json={"target_dir": str(dest), "instructions": instr},
+    )
+    assert resp.status_code == 200
+    data = client.get("/api/config").json()
+    assert data["config"]["target_dir"] == str(dest)
+    assert data["config"]["instructions"] == instr
+    row = new_db.conn.execute(
+        "SELECT value FROM config WHERE key='instructions'"
+    ).fetchone()
+    assert row["value"] == instr
+
+    client.post("/api/reset", json={"base_dir": str(base)})
+    row = new_db.conn.execute(
+        "SELECT value FROM config WHERE key='instructions'"
+    ).fetchone()
+    assert row is None
+    data = client.get("/api/config").json()
+    assert "instructions" not in data["config"]


### PR DESCRIPTION
## Summary
- allow configuring target storage path and general instructions
- persist target path and instructions in SQLite and expose via config API
- add tests for config persistence

## Testing
- `pylint agent_utils/agent_vector_db.py foldermate/app.py tests/test_config_persistence.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b32f8c947c832083f0de7adef991a1