### PR TITLE
feat(ui): enable folder selection for target path

### DIFF
--- a/foldermate/static/index.html
+++ b/foldermate/static/index.html
@@ -426,7 +426,24 @@
         state.basePath = $('#folderPath').value || base; renderBase(); toast('Folder selected'); saveConfig();
       }
     });
-    $('#browseTargetBtn').addEventListener('click', ()=> $('#targetPicker').click());
+    $('#browseTargetBtn').addEventListener('click', async () => {
+      // Try native folder picker via backend
+      try {
+        const r = await fetchJSON('/api/pick_folder');
+        if (r.ok && r.path) {
+          state.targetPath = r.path;
+          renderBase();
+          await saveConfig();
+          toast('Target folder selected');
+          return;
+        }
+      } catch (e) {
+        // ignore; we'll fallback below
+      }
+
+      // Fallback: use the hidden input (will NOT upload—just selects a folder)
+      $('#targetPicker').click();
+    });
     $('#targetPicker').addEventListener('change', (e)=>{
       const files = Array.from(e.target.files||[]);
       if(files.length){


### PR DESCRIPTION
## Summary
- allow target path browse button to use native folder picker with fallback

## Testing
- `pylint foldermate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b33714ac348320a3393c488d109ec4