### PR TITLE
Handle stale processing placeholders in file analysis

### DIFF
--- a/agent_utils/agent_vector_db.py
+++ b/agent_utils/agent_vector_db.py
@@ -81,6 +81,9 @@ DEFAULT_CONFIG = {
     },
 }
 
+# Placeholder markers used when a file analysis is in progress.
+PROCESSING_SENTINELS = ("processing...", "processing..")
+
 
 class AgentVectorDB:
     """Semantic vector database for file organization."""
@@ -364,7 +367,13 @@ class AgentVectorDB:
     @_safe_json
     def get_next_path_missing_file_report(self) -> dict:
         row = self.conn.execute(
-            "SELECT path_rel FROM files WHERE IFNULL(TRIM(file_report),'')='' ORDER BY id ASC LIMIT 1"
+            """
+            SELECT path_rel FROM files
+            WHERE IFNULL(TRIM(file_report),'')=''
+               OR file_report IN (?, ?)
+            ORDER BY id ASC LIMIT 1
+            """,
+            PROCESSING_SENTINELS,
         ).fetchone()
         return {"ok": True, "path_rel": row["path_rel"] if row else None}
 

--- a/foldermate/app.py
+++ b/foldermate/app.py
@@ -14,7 +14,7 @@ from fastapi.responses import FileResponse  # pylint: disable=import-error
 from fastapi.staticfiles import StaticFiles  # pylint: disable=import-error
 from pydantic import BaseModel, Field
 
-from agent_utils.agent_vector_db import AgentVectorDB
+from agent_utils.agent_vector_db import AgentVectorDB, PROCESSING_SENTINELS
 
 # ---------- App + CORS ----------
 BASE_DIR = os.path.dirname(__file__)
@@ -194,7 +194,7 @@ def _row_to_file_row(r) -> FileRow:
         organized_path=r["final_dest"],
         created_at=r["created_at"],
         updated_at=r["updated_at"],
-        has_file_report=bool(r["file_report"]),
+        has_file_report=bool(r["file_report"] and r["file_report"] not in PROCESSING_SENTINELS),
         has_organization_notes=bool(r["organization_notes"]),
     )
 
@@ -218,7 +218,7 @@ def _analyze_pending_files(base_dir: str) -> None:
         if not path_rel:
             break
         abs_path = os.path.join(base_dir_abs, path_rel)
-        db.set_file_report(path_rel, "processing...")
+        db.set_file_report(path_rel, PROCESSING_SENTINELS[0])
         runstate.status_text = f"Analyzing {path_rel}"
         report = ask_file_analysis_agent(abs_path)
         db.set_file_report(path_rel, report)


### PR DESCRIPTION
## Summary
- mark "processing" file reports as incomplete and retry analysis
- avoid treating placeholder reports as completed in UI

## Testing
- `pylint agent_utils foldermate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b33a79f57c8320ada8f1f0d1195132