### PR TITLE
feat: expose user instructions tool

### DIFF
--- a/agent_utils/agent_vector_db.py
+++ b/agent_utils/agent_vector_db.py
@@ -274,6 +274,20 @@ class AgentVectorDB:
         return {"ok": True, "base_dir": row["value"]}
 
     @_safe_json
+    def get_instructions(self) -> dict:
+        """Return user folder organization instructions.
+
+        The instructions are stored in the ``config`` table under the
+        ``instructions`` key.  If no instructions have been saved, an empty
+        string is returned.
+        """
+
+        row = self.conn.execute(
+            "SELECT value FROM config WHERE key='instructions'"
+        ).fetchone()
+        return {"ok": True, "instructions": row["value"] if row else ""}
+
+    @_safe_json
     def insert(self, path_from_base: str) -> dict:
         path_rel = _norm_rel(path_from_base)
         now = _iso_now()

--- a/file_organization_decider_agent/agent.py
+++ b/file_organization_decider_agent/agent.py
@@ -39,6 +39,12 @@ def get_organization_notes(path: str) -> dict:
 
 
 @agent.tool_plain
+def get_folder_instructions() -> dict:
+    """Return user folder organization instructions."""
+    return tools.get_folder_instructions()
+
+
+@agent.tool_plain
 def target_folder_tree(path: str) -> str:
     """Return a folder tree for ``path`` with a heading."""
     return tools.target_folder_tree(path)

--- a/file_organization_decider_agent/agent_tools/__init__.py
+++ b/file_organization_decider_agent/agent_tools/__init__.py
@@ -10,6 +10,7 @@ from .tools import (
     get_file_report,
     set_planned_destination,
     get_organization_notes,
+    get_folder_instructions,
     target_folder_tree,
 )
 
@@ -18,5 +19,6 @@ __all__ = [
     "get_file_report",
     "set_planned_destination",
     "get_organization_notes",
+    "get_folder_instructions",
     "target_folder_tree",
 ]

--- a/file_organization_decider_agent/agent_tools/tools.py
+++ b/file_organization_decider_agent/agent_tools/tools.py
@@ -33,6 +33,11 @@ def get_organization_notes(path: str) -> dict:
     return _db.get_organization_notes(path)
 
 
+def get_folder_instructions() -> dict:
+    """Retrieve user folder organization instructions."""
+    return _db.get_instructions()
+
+
 def target_folder_tree(path: str) -> str:
     """Return a folder tree for ``path`` with a heading."""
     return _target_folder_tree(path)

--- a/file_organization_planner_agent/agent.py
+++ b/file_organization_planner_agent/agent.py
@@ -33,6 +33,12 @@ def get_file_report(path: str) -> dict:
 
 
 @agent.tool_plain
+def get_folder_instructions() -> dict:
+    """Return user folder organization instructions."""
+    return tools.get_folder_instructions()
+
+
+@agent.tool_plain
 def target_folder_tree(path: str) -> str:
     """Return a folder tree for ``path`` with a heading."""
     return tools.target_folder_tree(path)

--- a/file_organization_planner_agent/agent_tools/__init__.py
+++ b/file_organization_planner_agent/agent_tools/__init__.py
@@ -1,13 +1,18 @@
-from .tools import (
-    find_similar_file_reports,
-    append_organization_notes,
-    get_file_report,
-    target_folder_tree,
-)
+"""Convenience exports for planner agent tools."""
+
+# pylint: disable=undefined-all-variable
+from . import tools as _tools
+
+find_similar_file_reports = _tools.find_similar_file_reports
+append_organization_notes = _tools.append_organization_notes
+get_file_report = _tools.get_file_report
+get_folder_instructions = _tools.get_folder_instructions
+target_folder_tree = _tools.target_folder_tree
 
 __all__ = [
     "find_similar_file_reports",
     "append_organization_notes",
     "get_file_report",
+    "get_folder_instructions",
     "target_folder_tree",
 ]

--- a/file_organization_planner_agent/agent_tools/tools.py
+++ b/file_organization_planner_agent/agent_tools/tools.py
@@ -25,6 +25,11 @@ def get_file_report(path: str) -> dict:
     return _db.get_file_report(path)
 
 
+def get_folder_instructions() -> dict:
+    """Retrieve user folder organization instructions."""
+    return _db.get_instructions()
+
+
 
 def get_db() -> AgentVectorDB:
     """Return the global database instance (primarily for tests)."""

--- a/tests/test_agent_vector_db.py
+++ b/tests/test_agent_vector_db.py
@@ -24,6 +24,9 @@ def test_agent_vector_db(tmp_path, monkeypatch):
     assert db.reset_db(str(base_dir))["ok"]
     assert db.get_base_dir()["base_dir"] == str(base_dir)
 
+    db.save_config(instructions="Keep PDFs in docs")
+    assert db.get_instructions()["instructions"] == "Keep PDFs in docs"
+
     ins1 = db.insert("file1.txt")
     ins2 = db.insert("file2.txt")
     db.set_file_report("file1.txt", "hello world")

--- a/tests/test_decider_tools.py
+++ b/tests/test_decider_tools.py
@@ -38,6 +38,11 @@ def test_decider_tools(tmp_path, monkeypatch):
     (base / "a.txt").write_text("")
     (base / "b.txt").write_text("")
 
+    db.save_config(instructions="Keep PDFs in docs")
+
+    instr = decider_tools.get_folder_instructions()
+    assert instr["instructions"] == "Keep PDFs in docs"
+
     notes = decider_tools.append_organization_notes([ins1["id"]], "note1")
     assert ins1["id"] in notes["updated_ids"]
 

--- a/tests/test_planner_tools.py
+++ b/tests/test_planner_tools.py
@@ -39,6 +39,11 @@ def test_planner_tools(tmp_path, monkeypatch):
     (base / "a.txt").write_text("")
     (base / "b.txt").write_text("")
 
+    db.save_config(instructions="Keep PDFs in docs")
+
+    instr = planner_tools.get_folder_instructions()
+    assert instr["instructions"] == "Keep PDFs in docs"
+
     rep = planner_tools.get_file_report("a.txt")
     assert rep["file_report"] == "hello world"
 


### PR DESCRIPTION
## Summary
- expose database instructions retrieval via `get_folder_instructions`
- wire planner and decider agents to new tool
- cover instruction retrieval with tests

## Testing
- `pytest`
- `pylint agent_utils file_organization_planner_agent file_organization_decider_agent`

------
https://chatgpt.com/codex/tasks/task_e_68b353ba436c8320abca77cab168b002