### PR TITLE
Clear stale file analysis markers on restart

### DIFF
--- a/foldermate/app.py
+++ b/foldermate/app.py
@@ -38,6 +38,7 @@ def ui_root():
     return FileResponse(INDEX_PATH)
 
 db = AgentVectorDB("organizer.config.json")
+db.clear_processing_file_reports()
 
 # ---------- Single-action state ----------
 class RunState:


### PR DESCRIPTION
## Summary
- add `clear_processing_file_reports` utility to wipe leftover `processing...` markers
- call new helper when API boots to avoid stale status
- cover processing marker cleanup with tests

## Testing
- `pylint agent_utils/agent_vector_db.py foldermate/app.py tests/test_agent_vector_db.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3581c124883208cdbfcb4b978ecd8