### PR TITLE
Refactor planner and decider agents to match analysis agent

### DIFF
--- a/file_organization_decider_agent/__init__.py
+++ b/file_organization_decider_agent/__init__.py
@@ -1,17 +1,22 @@
 """File organization decider agent package."""
 
+from .agent import agent, ask_file_organization_decider_agent
 from .agent_tools import (
     append_organization_notes,
     get_file_report,
     set_planned_destination,
     get_organization_notes,
+    get_folder_instructions,
     target_folder_tree,
 )
 
 __all__ = [
+    "agent",
+    "ask_file_organization_decider_agent",
     "append_organization_notes",
     "get_file_report",
     "set_planned_destination",
     "get_organization_notes",
+    "get_folder_instructions",
     "target_folder_tree",
 ]

--- a/file_organization_decider_agent/agent.py
+++ b/file_organization_decider_agent/agent.py
@@ -1,17 +1,57 @@
 """PydanticAI agent exposing file organization decider tools."""
 from __future__ import annotations
 
+from pathlib import Path
+import json
+import logging
+from typing import Any, AsyncIterable, Dict
+
 from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.usage import UsageLimits
+from pydantic_ai.messages import AgentStreamEvent
+from pydantic_ai.tools import RunContext
 
 from .agent_tools import tools
+from agent_utils import setup_logging
 
-agent = Agent(
-    "google-gla:gemini-1.5-flash",
-    system_prompt=(
-        "You are a file organization decision assistant. Use tools to manage notes "
-        "and set planned destinations."
-    ),
-)
+
+PROMPT_PATH = Path(__file__).with_name("prompt.md")
+ROOT_CONFIG = Path(__file__).resolve().parents[1] / "organizer.config.json"
+
+setup_logging(str(ROOT_CONFIG))
+logger = logging.getLogger(__name__)
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration for the decider agent from the main config file."""
+    with ROOT_CONFIG.open(encoding="utf-8") as config_file:
+        cfg = json.load(config_file)
+    agent_cfg = cfg.get("file_organization_decider_agent", {})
+    agent_cfg.setdefault("api_key", cfg.get("api_key", ""))
+    return agent_cfg
+
+
+def build_agent() -> Agent:
+    """Create an :class:`Agent` configured for organization decisions."""
+    config = load_config()
+    api_key = config.get("api_key")
+    model_name = config.get("model", "google-gla:gemini-1.5-flash")
+    system_prompt = PROMPT_PATH.read_text(encoding="utf-8")
+    model = OpenAIModel(model_name, provider=OpenAIProvider(api_key=api_key))
+    return Agent(model=model, system_prompt=system_prompt, retries=2)
+
+
+agent = build_agent()
+
+
+async def _log_event_stream(
+    _: RunContext[Any], stream: AsyncIterable[AgentStreamEvent]
+) -> None:
+    """Log events emitted during agent execution."""
+    async for event in stream:
+        logger.info("decider agent event: %s", event)
 
 
 @agent.tool_plain
@@ -48,3 +88,39 @@ def get_folder_instructions() -> dict:
 def target_folder_tree(path: str) -> str:
     """Return a folder tree for ``path`` with a heading."""
     return tools.target_folder_tree(path)
+
+
+def ask_file_organization_decider_agent(
+    path: str,
+    query: str = "Please decide the organization for file:",
+) -> str:
+    """Execute a query against the file organization decider agent.
+
+    Parameters
+    ----------
+    path:
+        Path to the file for which a decision is requested.
+    query:
+        Prompt requesting the decision. ``path`` is appended to this string.
+
+    Returns
+    -------
+    str
+        The agent's textual response.
+    """
+
+    agent_query = f"{query} {path}"
+    logger.info("file_organization_decider_agent query: %s", agent_query)
+    response = agent.run_sync(
+        agent_query,
+        usage_limits=UsageLimits(request_limit=20),
+        event_stream_handler=_log_event_stream,
+    )
+    logger.info(
+        "file_organization_decider_agent response: %s", response.output
+    )
+    return response.output
+
+
+__all__ = ["ask_file_organization_decider_agent", "agent"]
+

--- a/file_organization_decider_agent/prompt.md
+++ b/file_organization_decider_agent/prompt.md
@@ -1,0 +1,1 @@
+You are a placeholder prompt for the file organization decider agent.

--- a/file_organization_decider_agent/tool-test.py
+++ b/file_organization_decider_agent/tool-test.py
@@ -1,0 +1,5 @@
+"""Manual test for decider agent tools."""
+from file_organization_decider_agent import set_planned_destination
+
+if __name__ == "__main__":
+    print(set_planned_destination("sample.txt", "dest/sample"))

--- a/file_organization_planner_agent/__init__.py
+++ b/file_organization_planner_agent/__init__.py
@@ -1,5 +1,6 @@
 """File organization planner agent package."""
 
+from .agent import agent, ask_file_organization_planner_agent
 from .agent_tools import (
     append_organization_notes,
     find_similar_file_reports,
@@ -9,6 +10,8 @@ from .agent_tools import (
 )
 
 __all__ = [
+    "agent",
+    "ask_file_organization_planner_agent",
     "find_similar_file_reports",
     "append_organization_notes",
     "get_file_report",

--- a/file_organization_planner_agent/prompt.md
+++ b/file_organization_planner_agent/prompt.md
@@ -1,0 +1,1 @@
+You are a placeholder prompt for the file organization planner agent.

--- a/file_organization_planner_agent/tool-test.py
+++ b/file_organization_planner_agent/tool-test.py
@@ -1,0 +1,6 @@
+"""Manual test for planner agent tools."""
+from file_organization_planner_agent import find_similar_file_reports
+
+if __name__ == "__main__":
+    TEST_PATH = "D:/foldermate-test/laya-claim-6830304-2024-01-25.pdf"
+    print(find_similar_file_reports(TEST_PATH, top_k=3))


### PR DESCRIPTION
## Summary
- Refactor file_organization_planner_agent and file_organization_decider_agent to mirror file_analysis_agent setup
- Add placeholder prompts and expose ask functions and agent instances at the package level
- Provide simple tool-test scripts for manual verification

## Testing
- `pylint file_organization_planner_agent file_organization_decider_agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc73b413448320872e0d576f0b3283