### PR TITLE
Use root organizer config for agent tools

### DIFF
--- a/file_organization_decider_agent/agent_tools/tools.py
+++ b/file_organization_decider_agent/agent_tools/tools.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Iterable
 
 from agent_utils.agent_vector_db import AgentVectorDB
 from agent_utils.folder_tree import target_folder_tree as _target_folder_tree
 
-_CONFIG_PATH = os.environ.get("FILE_ORGANIZER_CONFIG", "organizer.config.json")
+_DEFAULT_CONFIG = Path(__file__).resolve().parents[2] / "organizer.config.json"
+_CONFIG_PATH = os.environ.get("FILE_ORGANIZER_CONFIG", str(_DEFAULT_CONFIG))
 
 # Global database instance used by the tools
 _db = AgentVectorDB(config_path=_CONFIG_PATH)

--- a/file_organization_planner_agent/agent_tools/tools.py
+++ b/file_organization_planner_agent/agent_tools/tools.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Iterable
 
 from agent_utils.agent_vector_db import AgentVectorDB
 from agent_utils.folder_tree import target_folder_tree
 
-_CONFIG_PATH = os.environ.get("FILE_ORGANIZER_CONFIG", "organizer.config.json")
+_DEFAULT_CONFIG = Path(__file__).resolve().parents[2] / "organizer.config.json"
+_CONFIG_PATH = os.environ.get("FILE_ORGANIZER_CONFIG", str(_DEFAULT_CONFIG))
 
 # Global database instance used by the tools
 _db = AgentVectorDB(config_path=_CONFIG_PATH)

--- a/tests/test_default_config_path.py
+++ b/tests/test_default_config_path.py
@@ -1,0 +1,40 @@
+"""Tests for default configuration path resolution."""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+class DummyDB:
+    """Simple stand-in for :class:`AgentVectorDB` recording the config path."""
+
+    def __init__(self, config_path: str):
+        self.config_path = config_path
+
+
+def _root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_planner_tools_default_config(monkeypatch):
+    monkeypatch.delenv("FILE_ORGANIZER_CONFIG", raising=False)
+    monkeypatch.setattr("agent_utils.agent_vector_db.AgentVectorDB", DummyDB)
+    planner_dir = _root() / "file_organization_planner_agent"
+    monkeypatch.chdir(planner_dir)
+    tools = importlib.reload(
+        importlib.import_module("file_organization_planner_agent.agent_tools.tools")
+    )
+    db = tools.get_db()
+    assert Path(db.config_path) == _root() / "organizer.config.json"
+
+
+def test_decider_tools_default_config(monkeypatch):
+    monkeypatch.delenv("FILE_ORGANIZER_CONFIG", raising=False)
+    monkeypatch.setattr("agent_utils.agent_vector_db.AgentVectorDB", DummyDB)
+    decider_dir = _root() / "file_organization_decider_agent"
+    monkeypatch.chdir(decider_dir)
+    tools = importlib.reload(
+        importlib.import_module("file_organization_decider_agent.agent_tools.tools")
+    )
+    db = tools.get_db()
+    assert Path(db.config_path) == _root() / "organizer.config.json"


### PR DESCRIPTION
## Summary
- default planner/decider tools to repository's `organizer.config.json`
- add regression tests for default config path resolution

## Testing
- `python -m pylint file_organization_planner_agent file_organization_decider_agent tests/test_default_config_path.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c7c62dc8320a50df61c48f6761d