### PR TITLE
Fix logging path usage for planner agent

### DIFF
--- a/agent_utils/__init__.py
+++ b/agent_utils/__init__.py
@@ -1,9 +1,11 @@
 """Shared utilities for the organizer agents.
 
-This module also configures logging for the project.  Logs are written to a
-timestamped file located in the directory specified by ``log_dir`` in the main
-``organizer.config.json`` file.  If the configuration file is missing the
-``log_dir`` entry, logs default to the current working directory.
+This module also configures logging for the project. Logs are written to a
+timestamped file located in the directory specified by ``log_dir`` in the
+main ``organizer.config.json`` file. If the configuration file is missing the
+``log_dir`` entry, logs default to the current working directory. The default
+configuration file path is resolved relative to the repository root so that
+logging behaves consistently regardless of the current working directory.
 """
 
 from __future__ import annotations
@@ -12,15 +14,20 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Union
 
 
-def setup_logging(config_path: str = "organizer.config.json") -> Path:
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "organizer.config.json"
+
+
+def setup_logging(config_path: Union[str, Path] = DEFAULT_CONFIG_PATH) -> Path:
     """Configure root logging from the organizer configuration.
 
     Parameters
     ----------
     config_path:
-        Path to the JSON configuration file.
+        Path to the JSON configuration file. Defaults to the repository's
+        ``organizer.config.json``.
 
     Returns
     -------
@@ -28,13 +35,16 @@ def setup_logging(config_path: str = "organizer.config.json") -> Path:
         The path to the log file being used.
     """
 
+    config_path = Path(config_path)
     try:
-        with open(config_path, "r", encoding="utf-8") as fh:
+        with config_path.open("r", encoding="utf-8") as fh:
             cfg = json.load(fh)
     except FileNotFoundError:  # pragma: no cover - handled gracefully
         cfg = {}
 
     log_dir = Path(cfg.get("log_dir", "."))
+    if not log_dir.is_absolute():
+        log_dir = config_path.parent / log_dir
     log_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     log_file = log_dir / f"{timestamp}.log"
@@ -43,6 +53,7 @@ def setup_logging(config_path: str = "organizer.config.json") -> Path:
         filename=str(log_file),
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
         level=logging.INFO,
+        force=True,
     )
     return log_file
 

--- a/tests/test_logging_path.py
+++ b/tests/test_logging_path.py
@@ -1,0 +1,37 @@
+"""Tests for logging configuration resolution."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def test_planner_agent_logging_respects_config(tmp_path, monkeypatch):
+    """Ensure logging honours the path in ``organizer.config.json``."""
+    root = _root()
+    config_file = root / "organizer.config.json"
+    original = config_file.read_text()
+    data = json.loads(original)
+    data["log_dir"] = str(tmp_path)
+    config_file.write_text(json.dumps(data, indent=2))
+
+    def _clear_agent_utils():
+        for name in list(sys.modules):
+            if name == "agent_utils" or name.startswith("agent_utils."):
+                sys.modules.pop(name, None)
+
+    try:
+        planner_dir = root / "file_organization_planner_agent"
+        monkeypatch.chdir(planner_dir)
+        _clear_agent_utils()
+        import agent_utils  # pylint: disable=import-outside-toplevel
+        log_files = list(tmp_path.glob("*.log"))
+        assert log_files, "Logging did not write to configured directory"
+        assert not list(planner_dir.glob("*.log")), "Log file written to agent directory"
+    finally:
+        config_file.write_text(original)
+        _clear_agent_utils()


### PR DESCRIPTION
## Summary
- ensure logging resolves log directories relative to `organizer.config.json`
- allow reconfiguring logging with `force=True`
- test that planner agent writes logs to the configured directory

## Testing
- `pylint agent_utils file_organization_planner_agent`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc8073017483208e0a90693d761df0