### PR TITLE
Use configured target folder for folder tree tools

### DIFF
--- a/file_organization_decider_agent/agent.py
+++ b/file_organization_decider_agent/agent.py
@@ -85,9 +85,9 @@ def get_folder_instructions() -> dict:
 
 
 @agent.tool_plain
-def target_folder_tree(path: str) -> str:
-    """Return a folder tree for ``path`` with a heading."""
-    return tools.target_folder_tree(path)
+def target_folder_tree() -> str:
+    """Return a folder tree for the configured target directory."""
+    return tools.target_folder_tree()
 
 
 def ask_file_organization_decider_agent(

--- a/file_organization_decider_agent/agent_tools/tools.py
+++ b/file_organization_decider_agent/agent_tools/tools.py
@@ -40,9 +40,19 @@ def get_folder_instructions() -> dict:
     return _db.get_instructions()
 
 
-def target_folder_tree(path: str) -> str:
-    """Return a folder tree for ``path`` with a heading."""
-    return _target_folder_tree(path)
+def target_folder_tree() -> str:
+    """Return a folder tree for the configured target directory.
+
+    Raises
+    ------
+    ValueError
+        If the ``target_dir`` configuration option has not been set.
+    """
+
+    target_dir = _db.config.get("target_dir")
+    if not target_dir:
+        raise ValueError("target_dir is not configured")
+    return _target_folder_tree(target_dir)
 
 
 def get_db() -> AgentVectorDB:

--- a/file_organization_planner_agent/agent.py
+++ b/file_organization_planner_agent/agent.py
@@ -79,9 +79,9 @@ def get_folder_instructions() -> dict:
 
 
 @agent.tool_plain
-def target_folder_tree(path: str) -> str:
-    """Return a folder tree for ``path`` with a heading."""
-    return tools.target_folder_tree(path)
+def target_folder_tree() -> str:
+    """Return a folder tree for the configured target directory."""
+    return tools.target_folder_tree()
 
 
 def ask_file_organization_planner_agent(
@@ -117,4 +117,3 @@ def ask_file_organization_planner_agent(
 
 
 __all__ = ["ask_file_organization_planner_agent", "agent"]
-

--- a/file_organization_planner_agent/agent_tools/tools.py
+++ b/file_organization_planner_agent/agent_tools/tools.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Iterable
 
 from agent_utils.agent_vector_db import AgentVectorDB
-from agent_utils.folder_tree import target_folder_tree
+from agent_utils.folder_tree import target_folder_tree as _target_folder_tree
 
 _DEFAULT_CONFIG = Path(__file__).resolve().parents[2] / "organizer.config.json"
 _CONFIG_PATH = os.environ.get("FILE_ORGANIZER_CONFIG", str(_DEFAULT_CONFIG))
@@ -30,6 +30,21 @@ def get_file_report(path: str) -> dict:
 def get_folder_instructions() -> dict:
     """Retrieve user folder organization instructions."""
     return _db.get_instructions()
+
+
+def target_folder_tree() -> str:
+    """Return a folder tree for the configured target directory.
+
+    Raises
+    ------
+    ValueError
+        If the ``target_dir`` configuration option has not been set.
+    """
+
+    target_dir = _db.config.get("target_dir")
+    if not target_dir:
+        raise ValueError("target_dir is not configured")
+    return _target_folder_tree(target_dir)
 
 
 

--- a/file_organizer_agent.md
+++ b/file_organizer_agent.md
@@ -38,7 +38,7 @@ JSON‑friendly helper functions:
 - `append_organization_notes(ids, notes)` – add free‑form notes to one or more file
   ids.
 - `get_file_report(path)` – retrieve the stored report for `path`.
-- `target_folder_tree(path)` – render a textual folder tree rooted at `path`.
+- `target_folder_tree()` – render a textual folder tree rooted at the configured target directory.
 
 These functions operate on a global `AgentVectorDB` instance and all results follow
 the pattern `{"ok": True, ...}` or contain an `"error"` field when something goes

--- a/tests/test_decider_tools.py
+++ b/tests/test_decider_tools.py
@@ -1,5 +1,4 @@
 import importlib
-import importlib
 import os
 
 from agent_utils.agent_vector_db import AgentVectorDB
@@ -38,7 +37,7 @@ def test_decider_tools(tmp_path, monkeypatch):
     (base / "a.txt").write_text("")
     (base / "b.txt").write_text("")
 
-    db.save_config(instructions="Keep PDFs in docs")
+    db.save_config(instructions="Keep PDFs in docs", target_dir=str(base))
 
     instr = decider_tools.get_folder_instructions()
     assert instr["instructions"] == "Keep PDFs in docs"
@@ -56,5 +55,5 @@ def test_decider_tools(tmp_path, monkeypatch):
     row = db.conn.execute("SELECT planned_dest FROM files WHERE path_rel='a.txt'").fetchone()
     assert row["planned_dest"] == "dest/a"
 
-    tree = decider_tools.target_folder_tree(str(base))
+    tree = decider_tools.target_folder_tree()
     assert "a.txt" in tree and "b.txt" in tree

--- a/tests/test_planner_tools.py
+++ b/tests/test_planner_tools.py
@@ -39,7 +39,7 @@ def test_planner_tools(tmp_path, monkeypatch):
     (base / "a.txt").write_text("")
     (base / "b.txt").write_text("")
 
-    db.save_config(instructions="Keep PDFs in docs")
+    db.save_config(instructions="Keep PDFs in docs", target_dir=str(base))
 
     instr = planner_tools.get_folder_instructions()
     assert instr["instructions"] == "Keep PDFs in docs"
@@ -53,6 +53,6 @@ def test_planner_tools(tmp_path, monkeypatch):
     sim = planner_tools.find_similar_file_reports("a.txt")
     assert any(r["path_rel"] == "a.txt" for r in sim["results"])
 
-    tree = planner_tools.target_folder_tree(str(base))
+    tree = planner_tools.target_folder_tree()
     assert f"Folder Tree for {base}" in tree
     assert "a.txt" in tree and "b.txt" in tree


### PR DESCRIPTION
## Summary
- Load the target folder tree from the database-configured `target_dir` instead of requiring a path argument.
- Mirror the same parameterless `target_folder_tree` tool in the decider agent.
- Refresh documentation and tests to reflect the new folder tree behaviour.

## Testing
- `pylint file_organization_planner_agent/agent.py file_organization_planner_agent/agent_tools/tools.py file_organization_decider_agent/agent.py file_organization_decider_agent/agent_tools/tools.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc84e56ff88320b5204cab5215eefa