### PR TITLE
Handle errors in folder tree traversal

### DIFF
--- a/agent_utils/folder_tree.py
+++ b/agent_utils/folder_tree.py
@@ -2,22 +2,57 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, Dict, List
 
 
-def target_folder_tree(path: str) -> str:
-    """Return a folder tree for ``path`` with a heading."""
+def target_folder_tree(path: str) -> Dict[str, Any]:
+    """Return a folder tree for ``path`` with a heading.
+
+    The function attempts to traverse ``path`` recursively while collecting any
+    errors encountered along the way.  All discovered entries are returned even
+    if some directories cannot be read.
+
+    Parameters
+    ----------
+    path:
+        Path for which a folder tree should be created.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the textual folder tree in ``"tree"`` and, if
+        any problems occurred, an ``"errors"`` list with human readable
+        descriptions of those issues.
+    """
+
     p = Path(path).expanduser()
-    lines = [f"Folder Tree for {p}:"]
+    lines: List[str] = [f"Folder Tree for {p}:"]
+    errors: List[str] = []
+
     if not p.exists():
         lines.append("[Path does not exist]")
-        return "\n".join(lines)
+        errors.append(f"Path does not exist: {p}")
+        return {"tree": "\n".join(lines), "errors": errors}
 
     def walk(current: Path, prefix: str = "") -> None:
-        entries = sorted(current.iterdir(), key=lambda e: (not e.is_dir(), e.name.lower()))
+        try:
+            entries = sorted(
+                current.iterdir(),
+                key=lambda e: (not e.is_dir(), e.name.lower()),
+            )
+        except Exception as exc:  # pragma: no cover - rare OS errors
+            errors.append(f"{current}: {exc}")
+            return
+
         count = len(entries)
         for idx, entry in enumerate(entries):
             connector = "└── " if idx == count - 1 else "├── "
-            if entry.is_dir():
+            try:
+                is_dir = entry.is_dir()
+            except Exception as exc:  # pragma: no cover - rare OS errors
+                errors.append(f"{entry}: {exc}")
+                continue
+            if is_dir:
                 lines.append(f"{prefix}{connector}{entry.name}/")
                 extension = "    " if idx == count - 1 else "│   "
                 walk(entry, prefix + extension)
@@ -28,4 +63,8 @@ def target_folder_tree(path: str) -> str:
         walk(p)
     else:
         lines.append(p.name)
-    return "\n".join(lines)
+
+    result: Dict[str, Any] = {"tree": "\n".join(lines)}
+    if errors:
+        result["errors"] = errors
+    return result

--- a/file_organization_decider_agent/agent.py
+++ b/file_organization_decider_agent/agent.py
@@ -85,7 +85,7 @@ def get_folder_instructions() -> dict:
 
 
 @agent.tool_plain
-def target_folder_tree() -> str:
+def target_folder_tree() -> dict:
     """Return a folder tree for the configured target directory."""
     return tools.target_folder_tree()
 

--- a/file_organization_decider_agent/agent_tools/tools.py
+++ b/file_organization_decider_agent/agent_tools/tools.py
@@ -40,8 +40,11 @@ def get_folder_instructions() -> dict:
     return _db.get_instructions()
 
 
-def target_folder_tree() -> str:
+def target_folder_tree() -> dict:
     """Return a folder tree for the configured target directory.
+
+    The returned dictionary mirrors :func:`agent_utils.folder_tree.target_folder_tree`
+    and may include an ``"errors"`` list if some paths could not be processed.
 
     Raises
     ------

--- a/file_organization_planner_agent/agent.py
+++ b/file_organization_planner_agent/agent.py
@@ -79,7 +79,7 @@ def get_folder_instructions() -> dict:
 
 
 @agent.tool_plain
-def target_folder_tree() -> str:
+def target_folder_tree() -> dict:
     """Return a folder tree for the configured target directory."""
     return tools.target_folder_tree()
 

--- a/file_organization_planner_agent/agent_tools/tools.py
+++ b/file_organization_planner_agent/agent_tools/tools.py
@@ -32,8 +32,12 @@ def get_folder_instructions() -> dict:
     return _db.get_instructions()
 
 
-def target_folder_tree() -> str:
+def target_folder_tree() -> dict:
     """Return a folder tree for the configured target directory.
+
+    The result dictionary always contains a ``"tree"`` key with the textual
+    representation and may include an ``"errors"`` list describing any
+    directories that could not be read.
 
     Raises
     ------

--- a/file_organizer_agent.md
+++ b/file_organizer_agent.md
@@ -38,11 +38,13 @@ JSON‑friendly helper functions:
 - `append_organization_notes(ids, notes)` – add free‑form notes to one or more file
   ids.
 - `get_file_report(path)` – retrieve the stored report for `path`.
-- `target_folder_tree()` – render a textual folder tree rooted at the configured target directory.
+- `target_folder_tree()` – return a dictionary with the textual folder tree and
+  an optional list of traversal errors.
 
-These functions operate on a global `AgentVectorDB` instance and all results follow
+These functions operate on a global `AgentVectorDB` instance. Most results follow
 the pattern `{"ok": True, ...}` or contain an `"error"` field when something goes
-wrong.
+wrong. `target_folder_tree` instead provides a `{"tree": ..., "errors": [...]}`
+dictionary so that partial traversal issues can be reported.
 
 ## Pydantic agent
 

--- a/tests/test_decider_tools.py
+++ b/tests/test_decider_tools.py
@@ -56,4 +56,5 @@ def test_decider_tools(tmp_path, monkeypatch):
     assert row["planned_dest"] == "dest/a"
 
     tree = decider_tools.target_folder_tree()
-    assert "a.txt" in tree and "b.txt" in tree
+    assert "a.txt" in tree["tree"] and "b.txt" in tree["tree"]
+    assert "errors" not in tree or not tree["errors"]

--- a/tests/test_planner_tools.py
+++ b/tests/test_planner_tools.py
@@ -54,5 +54,6 @@ def test_planner_tools(tmp_path, monkeypatch):
     assert any(r["path_rel"] == "a.txt" for r in sim["results"])
 
     tree = planner_tools.target_folder_tree()
-    assert f"Folder Tree for {base}" in tree
-    assert "a.txt" in tree and "b.txt" in tree
+    assert f"Folder Tree for {base}" in tree["tree"]
+    assert "a.txt" in tree["tree"] and "b.txt" in tree["tree"]
+    assert "errors" not in tree or not tree["errors"]


### PR DESCRIPTION
## Summary
- return folder tree information as a dictionary that records traversal errors
- propagate dictionary response through planner and decider tools and agents
- document and test new folder tree error reporting

## Testing
- `pylint agent_utils file_organization_planner_agent file_organization_decider_agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc88de78308320af7659c7931b0dd6