### PR TITLE
Handle timestamped organization notes

### DIFF
--- a/agent_vector_db.md
+++ b/agent_vector_db.md
@@ -41,7 +41,7 @@ db.insert('notes/todo.txt')
 # Attach a short report about the file
 db.set_file_report('notes/todo.txt', 'text from an OCR or manual summary')
 
-# Add personal organisation notes
+# Add personal organisation notes (stored as `[dd-mm-yy-hh:mm:ss]{Note: ...}`)
 db.append_organization_notes([1], 'Remember to move this to /archive')
 
 # Find similar reports using vector search
@@ -61,7 +61,7 @@ parameters for the search engine.  You can edit this JSON file directly or call
 | `reset_db(base_dir_abs)` | Create a fresh database and remember the absolute base directory. |
 | `insert(path_from_base)` | Register a file path relative to the base directory. |
 | `set_file_report(path, text)` | Store a block of descriptive text and index it for similarity search. |
-| `append_organization_notes(ids, notes)` | Add notes for one or more file ids. |
+| `append_organization_notes(ids, notes)` | Add timestamped notes for one or more file ids. |
 | `set_planned_destination(path, dest)` / `set_final_destination(path, dest)` | Track where a file should go or ended up. |
 | `find_similar_file_reports(path, top_k)` | Return paths with reports similar to the given file. |
 | `get_next_path_missing_*()` | Helper methods that return the next file path lacking a particular field. |

--- a/tests/test_agent_vector_db.py
+++ b/tests/test_agent_vector_db.py
@@ -57,7 +57,12 @@ def test_agent_vector_db(tmp_path, monkeypatch):
 
     notes_res = db.append_organization_notes([ins1["id"]], "note1")
     assert ins1["id"] in notes_res["updated_ids"]
-    assert db.get_organization_notes("file1.txt")["organization_notes"].startswith("note1")
+    notes_res = db.append_organization_notes([ins1["id"]], "note2")
+    assert ins1["id"] in notes_res["updated_ids"]
+    notes_lines = db.get_organization_notes("file1.txt")["organization_notes"].splitlines()
+    assert len(notes_lines) == 2
+    assert notes_lines[0].endswith("{Note: note1}")
+    assert notes_lines[1].endswith("{Note: note2}")
 
     db.set_planned_destination("file1.txt", "dest/a")
     db.set_final_destination("file1.txt", "final/a")


### PR DESCRIPTION
## Summary
- add timestamped note entries when appending organization notes
- update documentation and tests for timestamped notes

## Testing
- `pylint agent_utils tests/test_agent_vector_db.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc8d82b1708320800ba3869000f85a