### PR TITLE
feat: show planner processing

### DIFF
--- a/agent_utils/agent_vector_db.py
+++ b/agent_utils/agent_vector_db.py
@@ -320,6 +320,32 @@ class AgentVectorDB:
         return {"ok": True, "id": int(row["id"]), "path_rel": path_rel, "existed": existed}
 
     @_safe_json
+    def get_file_id(self, path_from_base: str) -> dict:
+        """Return the database identifier for ``path_from_base``.
+
+        Parameters
+        ----------
+        path_from_base:
+            File path relative to the base directory.
+
+        Returns
+        -------
+        dict
+            JSON-friendly result containing ``id`` and ``path_rel``.
+
+        Raises
+        ------
+        KeyError
+            If the path is not present in the database.
+        """
+
+        path_rel = _norm_rel(path_from_base)
+        row = self.conn.execute("SELECT id FROM files WHERE path_rel=?", (path_rel,)).fetchone()
+        if not row:
+            raise KeyError(f"path not found: {path_rel}")
+        return {"ok": True, "id": int(row["id"]), "path_rel": path_rel}
+
+    @_safe_json
     def set_file_report(self, path_from_base: str, text: str) -> dict:
         if not text or not text.strip():
             raise ValueError("file_report text is empty.")

--- a/foldermate/app.py
+++ b/foldermate/app.py
@@ -225,7 +225,7 @@ def _analyze_pending_files(base_dir: str) -> None:
         db.set_file_report(path_rel, report)
 
 
-def _plan_pending_files(base_dir: str) -> None:
+def _plan_pending_files(_base_dir: str) -> None:
     """Run the organization planner for all unprocessed files.
 
     The database is queried for files that have a ``file_report`` but have
@@ -241,14 +241,15 @@ def _plan_pending_files(base_dir: str) -> None:
         ask_file_organization_planner_agent,
     )
 
-    base_dir_abs = os.path.abspath(base_dir)
     while not runstate.cancel_event.is_set():
         next_path = db.get_next_path_pending_organization_plan()
         path_rel = next_path.get("path_rel") if isinstance(next_path, dict) else None
         if not path_rel:
             break
-        #db.append_organization_notes([<get id of the path_rel>], PROCESSING_SENTINELS[0]) <--
-        #abs_path = os.path.join(base_dir_abs, path_rel)
+        file_id_res = db.get_file_id(path_rel)
+        file_id = file_id_res.get("id") if isinstance(file_id_res, dict) else None
+        if file_id is not None:
+            db.append_organization_notes([file_id], PROCESSING_SENTINELS[0])
         runstate.status_text = f"Planning {path_rel}"
         ask_file_organization_planner_agent(path_rel)
         db.mark_organization_plan_processed(path_rel)

--- a/tests/test_agent_vector_db.py
+++ b/tests/test_agent_vector_db.py
@@ -140,3 +140,18 @@ def test_set_file_report_retries_on_locked(tmp_path, monkeypatch):
     res = db.set_file_report("foo.txt", "hello")
     assert res["ok"]
     assert db.get_file_report("foo.txt")["file_report"] == "hello"
+
+
+def test_get_file_id(tmp_path, monkeypatch):
+    """Ensure file identifiers can be retrieved without modifying rows."""
+
+    monkeypatch.setattr("agent_utils.agent_vector_db.TextEmbedding", FakeEmbedder)
+    config_path = tmp_path / "id.cfg"
+    db = AgentVectorDB(config_path=str(config_path))
+    base_dir = tmp_path / "b"
+    base_dir.mkdir()
+    db.reset_db(str(base_dir))
+
+    inserted = db.insert("foo.txt")
+    res = db.get_file_id("foo.txt")
+    assert res["id"] == inserted["id"]


### PR DESCRIPTION
## Summary
- add `get_file_id` to AgentVectorDB for lookup without insert
- use `get_file_id` in planner to append processing sentinel
- test retrieving file id by path

## Testing
- `pylint foldermate/app.py agent_utils/agent_vector_db.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d70b9d40832098321e7b54a2ebe6