### PR TITLE
Refine organization note timestamps

### DIFF
--- a/agent_vector_db.md
+++ b/agent_vector_db.md
@@ -41,7 +41,7 @@ db.insert('notes/todo.txt')
 # Attach a short report about the file
 db.set_file_report('notes/todo.txt', 'text from an OCR or manual summary')
 
-# Add personal organisation notes (stored as `[dd-mm-yy-hh:mm:ss]{Note: ...}`)
+# Add personal organisation notes (stored as `[dd-mm-yy-hh:mm:ss]...`)
 db.append_organization_notes([1], 'Remember to move this to /archive')
 
 # Find similar reports using vector search

--- a/tests/test_agent_vector_db.py
+++ b/tests/test_agent_vector_db.py
@@ -61,8 +61,8 @@ def test_agent_vector_db(tmp_path, monkeypatch):
     assert ins1["id"] in notes_res["updated_ids"]
     notes_lines = db.get_organization_notes("file1.txt")["organization_notes"].splitlines()
     assert len(notes_lines) == 2
-    assert notes_lines[0].endswith("{Note: note1}")
-    assert notes_lines[1].endswith("{Note: note2}")
+    assert notes_lines[0].endswith("note1")
+    assert notes_lines[1].endswith("note2")
 
     db.set_planned_destination("file1.txt", "dest/a")
     db.set_final_destination("file1.txt", "final/a")
@@ -120,7 +120,7 @@ def test_prepend_and_remove_sentinel(tmp_path, monkeypatch):
     db.append_organization_notes([inserted["id"]], "note1")
     db.prepend_organization_note_sentinel("note.txt", PROCESSING_SENTINELS[0])
     notes = db.get_organization_notes("note.txt")["organization_notes"].splitlines()
-    assert notes[1] == PROCESSING_SENTINELS[0]
+    assert notes[0] == PROCESSING_SENTINELS[0]
     db.remove_organization_note_sentinel("note.txt", PROCESSING_SENTINELS[0])
     remaining = db.get_organization_notes("note.txt")["organization_notes"].splitlines()
     assert PROCESSING_SENTINELS[0] not in remaining


### PR DESCRIPTION
## Summary
- drop the `Note:` wrapper when appending organization notes
- add processing sentinels without timestamps and strip them after use
- update tests and docs for new note format

## Testing
- `pylint agent_utils`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6c9c248cc8320a117c6ac82e32874