### PR TITLE
Add cluster and anchor note helpers

### DIFF
--- a/agent_utils/agent_vector_db.py
+++ b/agent_utils/agent_vector_db.py
@@ -409,7 +409,9 @@ class AgentVectorDB:
         return {"ok": True, "cleared": int(cur.rowcount)}
 
     @_safe_json
-    def append_organization_notes(self, ids: T.Iterable[int], notes_to_append: str) -> dict:
+    def append_organization_cluser_notes(
+        self, ids: T.Iterable[int], notes_to_append: str
+    ) -> dict:
         """Append timestamped organisation notes to the specified files.
 
         Parameters
@@ -460,6 +462,34 @@ class AgentVectorDB:
         self.conn.commit()
         logger.info("Appended organization notes to ids=%s", updated)
         return {"ok": True, "updated_ids": updated}
+
+    @_safe_json
+    def append_organization_anchor_notes(
+        self, path_rel: str, notes_to_append: str
+    ) -> dict:
+        """Append timestamped organisation notes for a single file by path.
+
+        Parameters
+        ----------
+        path_rel:
+            File path relative to the base directory.
+        notes_to_append:
+            Note text to append.
+
+        Returns
+        -------
+        dict
+            JSON-friendly result containing ``updated_ids`` with the single
+            updated file id.
+        """
+
+        norm = _norm_rel(path_rel)
+        row = self.conn.execute(
+            "SELECT id FROM files WHERE path_rel=?", (norm,)
+        ).fetchone()
+        if not row:
+            raise KeyError(f"path not found: {norm}")
+        return self.append_organization_cluser_notes([int(row["id"])], notes_to_append)
 
     @_safe_json
     def prepend_organization_note_sentinel(

--- a/agent_vector_db.md
+++ b/agent_vector_db.md
@@ -42,7 +42,9 @@ db.insert('notes/todo.txt')
 db.set_file_report('notes/todo.txt', 'text from an OCR or manual summary')
 
 # Add personal organisation notes (stored as `[dd-mm-yy-hh:mm:ss]...`)
-db.append_organization_notes([1], 'Remember to move this to /archive')
+db.append_organization_cluser_notes([1], 'Remember to move this to /archive')
+# Add a note for a single file using its path
+db.append_organization_anchor_notes('notes/todo.txt', 'rename to todo_2025')
 
 # Find similar reports using vector search
 similar = db.find_similar_file_reports('notes/todo.txt')
@@ -61,7 +63,8 @@ parameters for the search engine.  You can edit this JSON file directly or call
 | `reset_db(base_dir_abs)` | Create a fresh database and remember the absolute base directory. |
 | `insert(path_from_base)` | Register a file path relative to the base directory. |
 | `set_file_report(path, text)` | Store a block of descriptive text and index it for similarity search. |
-| `append_organization_notes(ids, notes)` | Add timestamped notes for one or more file ids. |
+| `append_organization_cluser_notes(ids, notes)` | Add timestamped notes for one or more file ids. |
+| `append_organization_anchor_notes(path, notes)` | Add timestamped notes for a single file path. |
 | `set_planned_destination(path, dest)` / `set_final_destination(path, dest)` | Track where a file should go or ended up. |
 | `find_similar_file_reports(path, top_k)` | Return paths with reports similar to the given file. |
 | `get_next_path_missing_*()` | Helper methods that return the next file path lacking a particular field. |

--- a/file_organization_decider_agent/__init__.py
+++ b/file_organization_decider_agent/__init__.py
@@ -2,7 +2,7 @@
 
 from .agent import agent, ask_file_organization_decider_agent
 from .agent_tools import (
-    append_organization_notes,
+    append_organization_cluser_notes,
     get_file_report,
     set_planned_destination,
     get_organization_notes,
@@ -13,7 +13,7 @@ from .agent_tools import (
 __all__ = [
     "agent",
     "ask_file_organization_decider_agent",
-    "append_organization_notes",
+    "append_organization_cluser_notes",
     "get_file_report",
     "set_planned_destination",
     "get_organization_notes",

--- a/file_organization_decider_agent/agent.py
+++ b/file_organization_decider_agent/agent.py
@@ -55,9 +55,9 @@ async def _log_event_stream(
 
 
 @agent.tool_plain
-def append_organization_notes(ids: list[int], notes: str) -> dict:
+def append_organization_cluser_notes(ids: list[int], notes: str) -> dict:
     """Append organization notes to the given file ``ids``."""
-    return tools.append_organization_notes(ids, notes)
+    return tools.append_organization_cluser_notes(ids, notes)
 
 
 @agent.tool_plain

--- a/file_organization_decider_agent/agent_tools/__init__.py
+++ b/file_organization_decider_agent/agent_tools/__init__.py
@@ -6,7 +6,7 @@ level provides a compact API for other modules.
 """
 
 from .tools import (
-    append_organization_notes,
+    append_organization_cluser_notes,
     get_file_report,
     set_planned_destination,
     get_organization_notes,
@@ -15,7 +15,7 @@ from .tools import (
 )
 
 __all__ = [
-    "append_organization_notes",
+    "append_organization_cluser_notes",
     "get_file_report",
     "set_planned_destination",
     "get_organization_notes",

--- a/file_organization_decider_agent/agent_tools/tools.py
+++ b/file_organization_decider_agent/agent_tools/tools.py
@@ -15,9 +15,9 @@ _CONFIG_PATH = os.environ.get("FILE_ORGANIZER_CONFIG", str(_DEFAULT_CONFIG))
 _db = AgentVectorDB(config_path=_CONFIG_PATH)
 
 
-def append_organization_notes(ids: Iterable[int], notes: str) -> dict:
+def append_organization_cluser_notes(ids: Iterable[int], notes: str) -> dict:
     """Append organization notes for the given file ``ids``."""
-    return _db.append_organization_notes(ids, notes)
+    return _db.append_organization_cluser_notes(ids, notes)
 
 
 def get_file_report(path: str) -> dict:

--- a/file_organization_planner_agent/__init__.py
+++ b/file_organization_planner_agent/__init__.py
@@ -2,7 +2,8 @@
 
 from .agent import agent, ask_file_organization_planner_agent
 from .agent_tools import (
-    append_organization_notes,
+    append_organization_cluser_notes,
+    append_organization_anchor_notes,
     find_similar_file_reports,
     get_file_report,
     get_folder_instructions,
@@ -13,7 +14,8 @@ __all__ = [
     "agent",
     "ask_file_organization_planner_agent",
     "find_similar_file_reports",
-    "append_organization_notes",
+    "append_organization_cluser_notes",
+    "append_organization_anchor_notes",
     "get_file_report",
     "get_folder_instructions",
     "target_folder_tree",

--- a/file_organization_planner_agent/agent.py
+++ b/file_organization_planner_agent/agent.py
@@ -61,9 +61,15 @@ def find_similar_file_reports(path: str) -> dict:
 
 
 @agent.tool_plain
-def append_organization_notes(ids: list[int], notes: str) -> dict:
+def append_organization_cluser_notes(ids: list[int], notes: str) -> dict:
     """Append organization notes to the given file ``ids``."""
-    return tools.append_organization_notes(ids, notes)
+    return tools.append_organization_cluser_notes(ids, notes)
+
+
+@agent.tool_plain
+def append_organization_anchor_notes(path: str, notes: str) -> dict:
+    """Append organization notes for the file at ``path``."""
+    return tools.append_organization_anchor_notes(path, notes)
 
 
 @agent.tool_plain

--- a/file_organization_planner_agent/agent_tools/__init__.py
+++ b/file_organization_planner_agent/agent_tools/__init__.py
@@ -1,7 +1,8 @@
 """Convenience exports for planner agent tools."""
 
 from .tools import (
-    append_organization_notes,
+    append_organization_cluser_notes,
+    append_organization_anchor_notes,
     find_similar_file_reports,
     get_file_report,
     get_folder_instructions,

--- a/file_organization_planner_agent/agent_tools/tools.py
+++ b/file_organization_planner_agent/agent_tools/tools.py
@@ -18,9 +18,14 @@ def find_similar_file_reports(path: str, top_k=10) -> dict:
     """Find semantically similar file reports for ``path``."""
     return _db.find_similar_file_reports(path, top_k=top_k)
 
-def append_organization_notes(ids: Iterable[int], notes: str) -> dict:
+def append_organization_cluser_notes(ids: Iterable[int], notes: str) -> dict:
     """Append organization notes for the given file ``ids``."""
-    return _db.append_organization_notes(ids, notes)
+    return _db.append_organization_cluser_notes(ids, notes)
+
+
+def append_organization_anchor_notes(path: str, notes: str) -> dict:
+    """Append organization notes for a single file specified by ``path``."""
+    return _db.append_organization_anchor_notes(path, notes)
 
 def get_file_report(path: str) -> dict:
     """Retrieve the stored file report for ``path``."""

--- a/file_organization_planner_agent/prompt.md
+++ b/file_organization_planner_agent/prompt.md
@@ -26,13 +26,13 @@ Call `target_folder_tree()` to fetch the configured target directory’s tree (s
 Call `find_similar_file_reports(path=ANCHOR_FILE_PATH)` to identify **semantically similar** files. Form clusters based on dominant tags (project > event > person/child > topic > type). Observe results where semantic similarity is also shown for top results. Pay attention to organization notes of similar files.
 
 **Step 5 — Cluster-level notes**
-For each cluster where files should be stored under the same hierarchy, call `append_organization_notes(ids=[...], notes="<ClusterNotes JSON>")`. Prefer **existing folders**; propose **one minimal new folder** only if none fits.
+For each cluster where files should be stored under the same hierarchy, call `append_organization_cluser_notes(ids=[...], notes="<ClusterNotes JSON>")`. Prefer **existing folders**; propose **one minimal new folder** only if none fits.
 
 **Step 6 — Destination selection (ties & ambiguity)**
 If multiple destinations are plausible, choose by precedence (see Constraints). Flag weak evidence for human review in the note.
 
 **Step 7 — Anchor-specific notes**
-Call `append_organization_notes(ids=[ANCHOR_ID], notes="<AnchorNotes JSON>")` including:
+Call `append_organization_anchor_notes(path=ANCHOR_FILE_PATH, notes="<AnchorNotes JSON>")` including:
 
 * **ProposedFolderPath** (reuse existing where possible)
 * **ProposedFilename** (date + project/org + doctype + topic/ID + version)
@@ -60,8 +60,10 @@ Call tools with JSON inputs. Prefer targeted calls.
 * `find_similar_file_reports(path: str) -> dict`
   Top 10 semantically similar file reports (ids/paths/tags/rationales).
 
-* `append_organization_notes(ids: Iterable[int], notes: str) -> dict`
-  Append **the same JSON note string** to every file id in `ids`. Use separate calls for cluster vs anchor.
+* `append_organization_cluser_notes(ids: Iterable[int], notes: str) -> dict`
+  Append **the same JSON note string** to every file id in `ids` for cluster-level notes.
+* `append_organization_anchor_notes(path: str, notes: str) -> dict`
+  Append notes for the anchor file identified by `path`.
 
 ---
 
@@ -78,7 +80,7 @@ Call tools with JSON inputs. Prefer targeted calls.
 ---
 
 ## Organization Notes — Required JSON Schemas
-Step 1 - call append_organization_notes([list of applicable IDs], "cluster notes") first
+Step 1 - call append_organization_cluser_notes([list of applicable IDs], "cluster notes") first
 ### A) ClusterNotes (attach to **all similar files** in the cluster that should be placed in the same proposed folder)
 Based on your analysis, identify paths of files (ProposedFilesForFolder), that can be included in the same folder (ProposedFolderPath) based on topic, theme, project and so on.
 Remember to add notes to all applicable files based on IDs.
@@ -99,7 +101,7 @@ Remember to add notes to all applicable files based on IDs.
   "NamingGuidance": { "FolderHint": "Projects/{ProjectName}/Design" }
 }
 ```
-Step 2 - call append_organization_notes([id of the current file under analysis], "anchor notes") again
+Step 2 - call append_organization_anchor_notes(path of the current file under analysis, "anchor notes")
 
 ### B) AnchorNotes (attach to **the anchor file only**)
 
@@ -153,12 +155,12 @@ Observations:
 ```
 Thought: Dominant tag = project: Alpha → reuse /Projects/Alpha/Design.
 Actions:
-- Action: append_organization_notes
+- Action: append_organization_cluser_notes
   Action Input: {
     "ids":[1293,4412,4510],
     "notes":"{\"Kind\":\"ClusterNotes\",\"ProposedFolderPath\":\"/Projects/Alpha/Design\",...}"
   }
-- Action: append_organization_notes
+- Action: append_organization_anchor_notes
   Action Input: {
     "ids":[1293],
     "notes":"{\"Kind\":\"AnchorNotes\",\"ProposedFolderPath\":\"/Projects/Alpha/Design\",\"ProposedFilename\":\"2025-03-14_Alpha_Design_Homepage_v02.pdf\",...}"
@@ -174,8 +176,8 @@ Observations:
 
 ## Output Rules
 
-* **Do not** produce any report or summary; your only deliverable is **appended notes** via `append_organization_notes`.
+* **Do not** produce any report or summary; your only deliverable is **appended notes** via `append_organization_cluser_notes` and `append_organization_anchor_notes`.
 * **Do not** move or rename files yourself.
 * Iterate tool calls until you can append **useful ClusterNotes** (for similar files) and **AnchorNotes** (for the anchor).
 * If evidence is missing, still append notes but include **low Confidence** and set **ReviewNeeded=true** with a clear rationale.
-* For each file given to you, append both cluter notes and anchor notes as two seperate calls to the tool append_organization_notes given to you
+* For each file given to you, append both cluster notes and anchor notes using the respective tools.

--- a/file_organizer_agent.md
+++ b/file_organizer_agent.md
@@ -35,8 +35,10 @@ JSON‑friendly helper functions:
 
 - `find_similar_file_reports(path, top_k=10)` – return file reports whose embeddings
   are close to `path`.
-- `append_organization_notes(ids, notes)` – add free‑form notes to one or more file
-  ids.
+- `append_organization_cluser_notes(ids, notes)` – add free‑form notes to one or
+  more file ids.
+- `append_organization_anchor_notes(path, notes)` – add notes to a single file
+  identified by its path.
 - `get_file_report(path)` – retrieve the stored report for `path`.
 - `target_folder_tree()` – return a dictionary with the textual folder tree and
   an optional list of traversal errors.

--- a/foldermate/app.py
+++ b/foldermate/app.py
@@ -499,7 +499,7 @@ def put_file_report(file_id: int, payload: FileReportUpdate):
 
 @app.post("/api/files/notes/append", response_model=Dict[str, Any])
 def append_notes(payload: NotesAppend):
-    return db.append_organization_notes(payload.ids, payload.text)
+    return db.append_organization_cluser_notes(payload.ids, payload.text)
 
 # ---------- Similarity ----------
 @app.get("/api/files/{file_id}/similar", response_model=SimilarOut)

--- a/tests/test_agent_vector_db.py
+++ b/tests/test_agent_vector_db.py
@@ -52,17 +52,21 @@ def test_agent_vector_db(tmp_path, monkeypatch):
     ins2 = db.insert("file2.txt")
     db.set_file_report("file1.txt", "hello world")
     db.set_file_report("file2.txt", "hello there")
+    db.append_organization_anchor_notes("file2.txt", "anchor")
 
     assert db.get_file_report("file1.txt")["file_report"] == "hello world"
 
-    notes_res = db.append_organization_notes([ins1["id"]], "note1")
+    notes_res = db.append_organization_cluser_notes([ins1["id"]], "note1")
     assert ins1["id"] in notes_res["updated_ids"]
-    notes_res = db.append_organization_notes([ins1["id"]], "note2")
+    notes_res = db.append_organization_cluser_notes([ins1["id"]], "note2")
     assert ins1["id"] in notes_res["updated_ids"]
     notes_lines = db.get_organization_notes("file1.txt")["organization_notes"].splitlines()
     assert len(notes_lines) == 2
     assert notes_lines[0].endswith("note1")
     assert notes_lines[1].endswith("note2")
+
+    anchor_lines = db.get_organization_notes("file2.txt")["organization_notes"].splitlines()
+    assert any(line.endswith("anchor") for line in anchor_lines)
 
     db.set_planned_destination("file1.txt", "dest/a")
     db.set_final_destination("file1.txt", "final/a")
@@ -70,7 +74,7 @@ def test_agent_vector_db(tmp_path, monkeypatch):
     # Insert third file for planned/final tests
     ins3 = db.insert("file3.txt")
     db.set_file_report("file3.txt", "hello world again")
-    db.append_organization_notes([ins3["id"]], "note3")
+    db.append_organization_cluser_notes([ins3["id"]], "note3")
     db.mark_organization_plan_processed("file1.txt")
     db.mark_organization_plan_processed("file3.txt")
 
@@ -117,7 +121,7 @@ def test_prepend_and_remove_sentinel(tmp_path, monkeypatch):
     base_dir.mkdir()
     db.reset_db(str(base_dir))
     inserted = db.insert("note.txt")
-    db.append_organization_notes([inserted["id"]], "note1")
+    db.append_organization_cluser_notes([inserted["id"]], "note1")
     db.prepend_organization_note_sentinel("note.txt", PROCESSING_SENTINELS[0])
     notes = db.get_organization_notes("note.txt")["organization_notes"].splitlines()
     assert notes[0] == PROCESSING_SENTINELS[0]

--- a/tests/test_decider_tools.py
+++ b/tests/test_decider_tools.py
@@ -42,7 +42,7 @@ def test_decider_tools(tmp_path, monkeypatch):
     instr = decider_tools.get_folder_instructions()
     assert instr["instructions"] == "Keep PDFs in docs"
 
-    notes = decider_tools.append_organization_notes([ins1["id"]], "note1")
+    notes = decider_tools.append_organization_cluser_notes([ins1["id"]], "note1")
     assert ins1["id"] in notes["updated_ids"]
 
     rep = decider_tools.get_file_report("a.txt")

--- a/tests/test_planner_tools.py
+++ b/tests/test_planner_tools.py
@@ -47,8 +47,11 @@ def test_planner_tools(tmp_path, monkeypatch):
     rep = planner_tools.get_file_report("a.txt")
     assert rep["file_report"] == "hello world"
 
-    notes = planner_tools.append_organization_notes([ins1["id"]], "note1")
+    notes = planner_tools.append_organization_cluser_notes([ins1["id"]], "note1")
     assert ins1["id"] in notes["updated_ids"]
+
+    anchor = planner_tools.append_organization_anchor_notes("a.txt", "anchor")
+    assert anchor["ok"]
 
     sim = planner_tools.find_similar_file_reports("a.txt")
     assert any(r["path_rel"] == "a.txt" for r in sim["results"])


### PR DESCRIPTION
## Summary
- rename `append_organization_notes` to `append_organization_cluser_notes`
- add `append_organization_anchor_notes` for single-file notes
- expose new note helpers via planner agent tools and prompt

## Testing
- `pylint agent_utils file_organization_planner_agent file_organization_decider_agent foldermate/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6d2461c9c832092e8ca40563cd4e3