### PR TITLE
feat: expose planned destination lookup

### DIFF
--- a/file_organization_decider_agent/__init__.py
+++ b/file_organization_decider_agent/__init__.py
@@ -6,6 +6,7 @@ from .agent_tools import (
     get_file_report,
     set_planned_destination,
     get_organization_notes,
+    get_planned_destination_folders,
     get_folder_instructions,
     target_folder_tree,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "get_file_report",
     "set_planned_destination",
     "get_organization_notes",
+    "get_planned_destination_folders",
     "get_folder_instructions",
     "target_folder_tree",
 ]

--- a/file_organization_decider_agent/agent.py
+++ b/file_organization_decider_agent/agent.py
@@ -13,8 +13,8 @@ from pydantic_ai.usage import UsageLimits
 from pydantic_ai.messages import AgentStreamEvent
 from pydantic_ai.tools import RunContext
 
-from .agent_tools import tools
 from agent_utils import setup_logging
+from .agent_tools import tools
 
 
 PROMPT_PATH = Path(__file__).with_name("prompt.md")
@@ -79,6 +79,12 @@ def get_organization_notes(path: str) -> dict:
 
 
 @agent.tool_plain
+def get_planned_destination_folders(proposed_folder_path: str) -> str:
+    """Report planned destinations for a ``ProposedFolderPath`` value."""
+    return tools.get_planned_destination_folders(proposed_folder_path)
+
+
+@agent.tool_plain
 def get_folder_instructions() -> dict:
     """Return user folder organization instructions."""
     return tools.get_folder_instructions()
@@ -123,4 +129,3 @@ def ask_file_organization_decider_agent(
 
 
 __all__ = ["ask_file_organization_decider_agent", "agent"]
-

--- a/file_organization_decider_agent/agent_tools/__init__.py
+++ b/file_organization_decider_agent/agent_tools/__init__.py
@@ -10,6 +10,7 @@ from .tools import (
     get_file_report,
     set_planned_destination,
     get_organization_notes,
+    get_planned_destination_folders,
     get_folder_instructions,
     target_folder_tree,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "get_file_report",
     "set_planned_destination",
     "get_organization_notes",
+    "get_planned_destination_folders",
     "get_folder_instructions",
     "target_folder_tree",
 ]

--- a/file_organization_decider_agent/agent_tools/tools.py
+++ b/file_organization_decider_agent/agent_tools/tools.py
@@ -35,6 +35,37 @@ def get_organization_notes(path: str) -> dict:
     return _db.get_organization_notes(path)
 
 
+def get_planned_destination_folders(proposed_folder_path: str) -> str:
+    """Report existing planned destinations for a proposed folder path.
+
+    Parameters
+    ----------
+    proposed_folder_path:
+        The ``ProposedFolderPath`` value to look up within cluster notes.
+
+    Returns
+    -------
+    str
+        Summary of unique destination folders already decided for the
+        ``proposed_folder_path``.
+    """
+
+    res = _db.planned_destination_folders_for_proposed(proposed_folder_path)
+    if not res.get("ok"):
+        return str(res)
+    folders: list[str] = res.get("folders", [])
+    if not folders:
+        return (
+            f"For proposed {proposed_folder_path}, no existing destination paths have been found"
+        )
+    folder_lines = "\n".join(folders)
+    header = (
+        f"For proposed {proposed_folder_path}, "
+        "found following destination paths already decided:\n\n"
+    )
+    return f"{header}{folder_lines}"
+
+
 def get_folder_instructions() -> dict:
     """Retrieve user folder organization instructions."""
     return _db.get_instructions()

--- a/tests/test_decider_tools.py
+++ b/tests/test_decider_tools.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import os
 
 from agent_utils.agent_vector_db import AgentVectorDB
@@ -58,3 +59,24 @@ def test_decider_tools(tmp_path, monkeypatch):
     tree = decider_tools.target_folder_tree()
     assert "a.txt" in tree["tree"] and "b.txt" in tree["tree"]
     assert "errors" not in tree or not tree["errors"]
+
+    # cluster notes and planned destination folder lookups
+    cluster_json = json.dumps(
+        {"Kind": "ClusterNotes", "ProposedFolderPath": "/Personal/Health/Laya_OutpatientClaims"}
+    )
+    decider_tools.append_organization_cluser_notes([ins1["id"]], cluster_json)
+    decider_tools.append_organization_cluser_notes([ins2["id"]], cluster_json)
+    decider_tools.set_planned_destination(
+        "a.txt", str(base / "Personal/Health/Laya_OutpatientClaims/a.txt")
+    )
+    decider_tools.set_planned_destination(
+        "b.txt", str(base / "Personal/Health/InsuranceClaims/b.txt")
+    )
+
+    res = decider_tools.get_planned_destination_folders(
+        "/Personal/Health/Laya_OutpatientClaims"
+    )
+    assert "/Personal/Health/Laya_OutpatientClaims" in res
+    assert "/Personal/Health/InsuranceClaims" in res
+    empty = decider_tools.get_planned_destination_folders("/Nonexistent")
+    assert "no existing destination" in empty.lower()


### PR DESCRIPTION
## Summary
- add database query for planned destinations by ProposedFolderPath
- expose lookup to decider agent tools and public API
- cover planned-destination lookup with tests

## Testing
- `pylint agent_utils file_organization_decider_agent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6e3a94b308320a670c209897abe49