### PR TITLE
Integrate decider agent with final decision flow

### DIFF
--- a/file_organization_decider_agent/agent.py
+++ b/file_organization_decider_agent/agent.py
@@ -53,23 +53,10 @@ async def _log_event_stream(
     async for event in stream:
         logger.info("decider agent event: %s", event)
 
-
-@agent.tool_plain
-def append_organization_cluser_notes(ids: list[int], notes: str) -> dict:
-    """Append organization notes to the given file ``ids``."""
-    return tools.append_organization_cluser_notes(ids, notes)
-
-
 @agent.tool_plain
 def get_file_report(path: str) -> dict:
     """Retrieve the stored file report for ``path``."""
     return tools.get_file_report(path)
-
-
-@agent.tool_plain
-def set_planned_destination(path: str, planned_dest: str) -> dict:
-    """Set the planned destination for ``path``."""
-    return tools.set_planned_destination(path, planned_dest)
 
 
 @agent.tool_plain


### PR DESCRIPTION
## Summary
- remove the unused note and planned destination tools from the decider agent definition
- add a background worker that drives the final decision loop and surfaces per-row processing sentinels
- validate decider output before storing it so the UI shows either a destination path or a bracketed error message

## Testing
- pytest
- pylint file_organization_decider_agent/agent.py foldermate/app.py

------
https://chatgpt.com/codex/tasks/task_e_68d05827d52c8320a4335ecf7cf86848