### PR TITLE
Add configuration for file organization decider agent

### DIFF
--- a/organizer.config.json
+++ b/organizer.config.json
@@ -27,6 +27,11 @@
     "encoding_name": "cl100k_base",
     "conversion_timeout": 45
   },
+  "file_organization_decider_agent": {
+    "model": "gpt-5-nano",
+    "max_return_chars": 200000,
+    "token_limit": 100000
+  },
   "file_organization_planner_agent": {
     "model": "gpt-5-nano",
     "max_return_chars": 200000,


### PR DESCRIPTION
## Summary
- add a configuration block for the file_organization_decider_agent
- align its model, return character limit, and token limit with the planner agent defaults

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d05c09d15883209f906361c4834297