### PR TITLE
Avoid duplicating runtime config in JSON

### DIFF
--- a/organizer.config.json
+++ b/organizer.config.json
@@ -1,8 +1,5 @@
 {
   "db_path": "organizer.sqlite",
-  "base_dir": "D:\\_dev",
-  "target_dir": "D:\\_organized",
-  "instructions": "",
   "embedding_model": "BAAI/bge-small-en-v1.5",
   "search": {
     "top_k": 10,


### PR DESCRIPTION
## Summary
- stop persisting runtime-only paths and instructions to the JSON config file
- reload configuration values from SQLite so API responses continue to expose saved settings
- generate sanitized config files that omit base, target, and instruction entries

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68d98800499c8320919f598a1eccfefb