### PR TITLE
docs: refresh README for FolderMate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,136 @@
-# Running 
-(foldermate) drive:\path\organizer>uvicorn foldermate.app:app --reload
+# FolderMate
 
-# File Analysis Agent
+FolderMate is a local-first workspace for auditing messy folders and safely reorganizing
+their contents. It combines a FastAPI backend, a lightweight semantic SQLite database,
+and a suite of domain-specific PydanticAI agents that analyse files, plan folder
+structures, and decide final destinations. The included single-page UI lets you scan a
+source directory, review suggested moves, and apply changes with confidence.
 
-Utilities for converting a single local document to Markdown and exposing light‑weight
-inspection tools for other AI agents.  The project focuses on reusable Markdown
-conversion, caching and simple line based queries.
+## What it does
+
+* Scans a source directory (recursively if desired) and records file metadata in a
+  SQLite database with semantic embeddings for similarity search.
+* Generates Markdown reports for each file via the **File Analysis Agent** so that
+  language-model driven workflows can reference consistent summaries.
+* Plans folder structures and grouping strategies using the **Organization Planner
+  Agent**.
+* Chooses final destinations for reviewed files using the **Organization Decider
+  Agent**, preserving audit trails and notes.
+* Exposes a REST API and static UI for configuring runs, reviewing analyses, selecting
+  files to move, and triggering long-running actions such as scanning, planning, and
+  moving files.
+
+## Design decisions
+
+* **Semantic store** – File metadata, analysis reports, and organization notes live in a
+  single SQLite database extended with [`sqlite-vec`](https://github.com/asg017/sqlite-vec)
+  and [`fastembed`](https://github.com/qdrant/fastembed) for fast local vector search. It
+  keeps the deployment self-contained and auditable.
+* **Config-as-JSON** – All runtime settings are loaded from `organizer.config.json`. This
+  makes it easy to script changes, share presets, and bootstrap new environments without
+  secrets in code.
+* **Composable agents** – Each agent (analysis, planner, decider) exposes its tools via
+  [PydanticAI](https://github.com/pydantic/pydantic-ai), enabling synchronous use from the
+  API or external automations while keeping logging and usage limits consistent.
+* **Explicit long-running state** – The FastAPI layer serialises actions (`scan`,
+  `analyze`, `plan`, `decide`, `move`) so that only one runs at a time. This avoids race
+  conditions when multiple operations compete for the same files or embeddings.
+* **Static front-end** – The UI is served from `foldermate/static`, keeping deployment as
+  simple as running `uvicorn` without extra build steps.
+
+## Code organization
+
+```
+organizer/
+├── agent_utils/                 # Shared utilities (vector DB, logging helpers)
+├── file_analysis_agent/         # Markdown conversion tools and agent wrapper
+├── file_organization_planner_agent/  # Planner agent plus helper tools
+├── file_organization_decider_agent/  # Decider agent plus helper tools
+├── foldermate/                  # FastAPI app and static SPA for orchestration
+├── tests/                       # Pytest coverage for key flows
+├── organizer.config.json        # Default runtime configuration
+└── pyproject.toml               # Project metadata and Python dependencies
+```
 
 ## Installation
 
+FolderMate targets Python 3.12+.
+
 ```bash
+python -m venv .venv
+source .venv/bin/activate  # or .\.venv\Scripts\activate on Windows
 pip install -e .
-# optional dependency for formats like PDF, DOCX, PPTX ...
-pip install -e .[docling]
 ```
+
+Optional extras:
+
+* Document conversion for PDFs, Office formats, etc.: `pip install -e .[docling]`
+* FastAPI server dependencies (if not already present in your environment):
+  `pip install fastapi uvicorn pydantic` (the API also uses `sqlite-vec`, `fastembed`,
+  `numpy`, and `pysqlite3-binary`, all pinned in `pyproject.toml`).
 
 ## Configuration
 
-Default settings live in the ``file_analysis_agent`` section of
-``organizer.config.json``:
+Runtime behaviour is controlled by `organizer.config.json`. Key sections include:
 
-```json
-"file_analysis_agent": {
-  "model": "gpt-5-nano",
-  "cache_dir": "~/.file_analysis_cache",
-  "max_return_chars": 5000,
-  "regex_default_flags": "im",
-  "token_limit": 4000,
-  "encoding_name": "cl100k_base",
-  "conversion_timeout": 45
-}
-```
+* **Top-level settings**
+  * `db_path` – SQLite database file used by `AgentVectorDB`.
+  * `base_dir` / `target_dir` – Source directory to audit and destination root for moves.
+  * `instructions` – Free-form guidance for the planner/decider agents.
+  * `recursive` – Whether scans traverse subdirectories.
+  * `dont_delete` – Guard rail flag; when `true`, move operations avoid destructive
+    deletes.
+  * `embedding_model` – FastEmbed model identifier for vector search.
+  * `search` and `sqlite` – Tunables for similarity search and SQLite pragmas.
+  * `api_key` – Upstream LLM key shared with agents (leave blank for mock/testing).
+* **Agent sections** (`file_analysis_agent`, `file_organization_planner_agent`,
+  `file_organization_decider_agent`) – Model names, token limits, and other overrides
+  passed directly to each agent wrapper.
 
-Edit this file to change the defaults.  Settings can also be tweaked at runtime:
+Update the JSON manually or via `AgentVectorDB.save_config()` methods exposed through the
+API. The FastAPI `/api/config` endpoints support reading and patching settings at runtime.
 
-```python
-from file_analysis_agent import update_config
-update_config(max_return_chars=10000)
-```
+## Running FolderMate
 
-## Usage
+1. Ensure `organizer.config.json` points at the folders you want to analyse and contains
+   any agent instructions.
+2. Start the API and static UI:
 
-### Tools directly
+   ```bash
+   uvicorn foldermate.app:app --reload
+   ```
 
-The tools can be imported and exercised independently of any LLM:
+3. Open `http://127.0.0.1:8000/` to access the UI. From there you can:
+   * Trigger scans to populate the database.
+   * Launch analysis/planning/decision actions.
+   * Review file reports, notes, and suggested destinations.
+   * Select files and initiate move operations.
 
-```python
-from file_analysis_agent import tools
+Automations can interact directly with the REST endpoints documented in
+`foldermate/app.py` (e.g. `/api/actions/scan`, `/api/files/{id}/report`, `/api/stop`).
 
-# convert and cache
-tools.set("/path/to/document.pdf")
+## Dependencies
 
-# inspect
-snippet = tools.top(start_line=10, num_lines=5)
-print(snippet["text"])
-```
+Core dependencies (see `pyproject.toml` for exact versions):
 
-Run the tests for individual tools with:
-
-```bash
-pytest tests/test_tools.py::test_set_and_top
-```
-
-### Pydantic agent
-
-A ready‑made `pydantic_ai.Agent` exposes the same tools for use in larger
-workflows:
-
-```python
-from file_analysis_agent.agent import agent
-
-agent.run("Use set('/path/to/file.txt')")
-agent.run("Show the top 5 lines")
-```
-
-## Custom runs and cache management
-
-`cache_dir` controls where converted Markdown and metadata are stored.  Remove a
-cached file programmatically with:
-
-```python
-from file_analysis_agent import tools
-
-tools.delete_cache("/path/to/file.txt")
-```
+* [`pydantic`](https://docs.pydantic.dev/) and [`pydantic-ai`](https://github.com/pydantic/pydantic-ai)
+  for strongly-typed agent execution.
+* [`tiktoken`](https://github.com/openai/tiktoken) for token-aware truncation.
+* [`diskcache`](https://grantjenks.com/docs/diskcache/) for local cache management.
+* [`sqlite-vec`](https://github.com/asg017/sqlite-vec), [`fastembed`](https://github.com/qdrant/fastembed),
+  and `numpy` for semantic search.
+* [`pysqlite3-binary`](https://github.com/coleifer/pysqlite3) to ensure SQLite extension
+  support on platforms that need it.
+* [`fastapi`](https://fastapi.tiangolo.com/) and [`uvicorn`](https://www.uvicorn.org/)
+  for serving the API and UI.
 
 ## Testing
 
-Run the full test suite with:
+Run the automated checks with:
 
 ```bash
 pytest
 ```
 
-## Design notes
+Linting is encouraged via `pylint`, targeting a score above 9.0 for touched modules.
 
-* Configuration is validated with Pydantic and stored in a JSON file for easy editing.
-* Markdown conversion uses [IBM Docling](https://github.com/docling-project) when available; plain text formats are read directly.
-* Results are cached with atomic writes and accompanied by metadata sidecars.
-* Tool outputs are truncated to `max_return_chars` and `read_full_file` enforces a
-  token limit to keep responses compact.
-* Only one document is analysed at a time to keep the interface predictable.

--- a/file_analysis_agent/README.md
+++ b/file_analysis_agent/README.md
@@ -1,0 +1,100 @@
+# File Analysis Agent
+
+Utilities for converting a single local document to Markdown and exposing light‑weight
+inspection tools for other AI agents.  The project focuses on reusable Markdown
+conversion, caching and simple line based queries.
+
+## Installation
+
+```bash
+pip install -e .
+# optional dependency for formats like PDF, DOCX, PPTX ...
+pip install -e .[docling]
+```
+
+## Configuration
+
+Default settings live in the ``file_analysis_agent`` section of
+``organizer.config.json``:
+
+```json
+"file_analysis_agent": {
+  "model": "gpt-5-nano",
+  "cache_dir": "~/.file_analysis_cache",
+  "max_return_chars": 5000,
+  "regex_default_flags": "im",
+  "token_limit": 4000,
+  "encoding_name": "cl100k_base",
+  "conversion_timeout": 45
+}
+```
+
+Edit this file to change the defaults.  Settings can also be tweaked at runtime:
+
+```python
+from file_analysis_agent import update_config
+update_config(max_return_chars=10000)
+```
+
+## Usage
+
+### Tools directly
+
+The tools can be imported and exercised independently of any LLM:
+
+```python
+from file_analysis_agent import tools
+
+# convert and cache
+tools.set("/path/to/document.pdf")
+
+# inspect
+snippet = tools.top(start_line=10, num_lines=5)
+print(snippet["text"])
+```
+
+Run the tests for individual tools with:
+
+```bash
+pytest tests/test_tools.py::test_set_and_top
+```
+
+### Pydantic agent
+
+A ready‑made `pydantic_ai.Agent` exposes the same tools for use in larger
+workflows:
+
+```python
+from file_analysis_agent.agent import agent
+
+agent.run("Use set('/path/to/file.txt')")
+agent.run("Show the top 5 lines")
+```
+
+## Custom runs and cache management
+
+`cache_dir` controls where converted Markdown and metadata are stored.  Remove a
+cached file programmatically with:
+
+```python
+from file_analysis_agent import tools
+
+tools.delete_cache("/path/to/file.txt")
+```
+
+## Testing
+
+Run the full test suite with:
+
+```bash
+pytest
+```
+
+## Design notes
+
+* Configuration is validated with Pydantic and stored in a JSON file for easy editing.
+* Markdown conversion uses [IBM Docling](https://github.com/docling-project) when available; plain text formats are read directly.
+* Results are cached with atomic writes and accompanied by metadata sidecars.
+* Tool outputs are truncated to `max_return_chars` and `read_full_file` enforces a
+  token limit to keep responses compact.
+* Only one document is analysed at a time to keep the interface predictable.


### PR DESCRIPTION
## Summary
- replace the root README with a project-level guide to FolderMate, covering functionality, architecture, configuration, and operations
- move the file analysis agent documentation into file_analysis_agent/README.md so its usage guidance remains available in the package

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d98a5473a483208ecd10005b18bb1d