### PR TITLE
Add FolderMate extra and document Windows quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,20 @@ pip install -e .
 Optional extras:
 
 * Document conversion for PDFs, Office formats, etc.: `pip install -e .[docling]`
-* FastAPI server dependencies (if not already present in your environment):
-  `pip install fastapi uvicorn pydantic` (the API also uses `sqlite-vec`, `fastembed`,
-  `numpy`, and `pysqlite3-binary`, all pinned in `pyproject.toml`).
+* FolderMate UI and server stack: `pip install -e .[foldermate]` to add FastAPI,
+  Uvicorn, and related web dependencies on top of the core agents.
+
+## Windows quick start
+
+Open **PowerShell** and install the complete FolderMate stack with the built-in Python
+launcher:
+
+```powershell
+py -m pip install organizer[foldermate]
+```
+
+This brings in the FastAPI server, Uvicorn, and supporting packages alongside the agent
+dependencies so the UI and automation tools are ready to run.
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,22 @@ dependencies = [
 
 [project.optional-dependencies]
 docling = ["docling"]
+foldermate = [
+    "fastapi",
+    "uvicorn[standard]",
+    "python-multipart",
+    "jinja2",
+]
 
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = [
+    "agent_utils",
+    "file_analysis_agent",
+    "file_organization_planner_agent",
+    "file_organization_decider_agent",
+    "foldermate",
+]


### PR DESCRIPTION
## Summary
- add a `foldermate` optional dependency group bundling the FastAPI/Uvicorn server stack
- document the PowerShell installation command in a new Windows quick start section
- configure setuptools to package the existing modules for editable installs

## Testing
- python -m pip install -e .[foldermate]
- python - <<'PY'\nimport fastapi\nimport uvicorn\nPY
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d98ec057c0832089ece95045799c67