### PR TITLE
Add CLI entrypoint for FolderMate server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ py -m pip install organizer[foldermate]
 ```
 
 This brings in the FastAPI server, Uvicorn, and supporting packages alongside the agent
-dependencies so the UI and automation tools are ready to run.
+dependencies so the UI and automation tools are ready to run. After installation you can
+start the app with the `foldermate` command (or `py -m foldermate.cli`) and the default
+interface will be available at `http://127.0.0.1:8000/`.
 
 ## Configuration
 
@@ -106,13 +108,16 @@ API. The FastAPI `/api/config` endpoints support reading and patching settings a
 
 1. Ensure your local `organizer.config.json` points at the folders you want to
    analyse and contains any agent instructions.
-2. Start the API and static UI:
+2. Start the API and static UI (override `--host/--port` if needed):
 
    ```bash
-   uvicorn foldermate.app:app --reload
+   foldermate
    ```
 
-3. Open `http://127.0.0.1:8000/` to access the UI. From there you can:
+   On Windows the same entrypoint is also exposed as `py -m foldermate.cli`.
+
+3. By default the server listens on `http://127.0.0.1:8000/`. Open that URL in your
+   browser to access the UI. From there you can:
    * Trigger scans to populate the database.
    * Launch analysis/planning/decision actions.
    * Review file reports, notes, and suggested destinations.

--- a/foldermate/cli.py
+++ b/foldermate/cli.py
@@ -1,0 +1,88 @@
+"""Command-line entrypoint for running the FolderMate server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+import uvicorn  # pylint: disable=import-error
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DEFAULT_CONFIG_NAME = "organizer.config.json"
+
+
+def load_config(config_path: Path) -> Dict[str, Any]:
+    """Load and validate the runtime configuration.
+
+    Parameters
+    ----------
+    config_path:
+        Location of the configuration JSON file.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed configuration contents.
+
+    Raises
+    ------
+    SystemExit
+        Raised when the configuration cannot be read or contains invalid JSON.
+    """
+
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive guard
+        raise SystemExit(f"Configuration file not found: {config_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON in configuration file: {config_path}") from exc
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the CLI entrypoint."""
+
+    parser = argparse.ArgumentParser(description="Run the FolderMate web application.")
+    parser.add_argument(
+        "--host",
+        default=DEFAULT_HOST,
+        help="Hostname or IP address to bind to.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help="TCP port number to listen on.",
+    )
+    parser.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG_NAME,
+        help="Path to organizer.config.json.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Parse arguments, load configuration, and start Uvicorn."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    config_path = Path(args.config).expanduser().resolve()
+    config = load_config(config_path)
+    base_dir = config.get("base_dir")
+    if base_dir:
+        LOGGER.info("Loaded configuration from %s (base_dir=%s)", config_path, base_dir)
+    else:
+        LOGGER.info("Loaded configuration from %s", config_path)
+
+    uvicorn.run("foldermate.app:app", host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ foldermate = [
     "jinja2",
 ]
 
+[project.scripts]
+foldermate = "foldermate.cli:main"
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add a `foldermate.cli` module that loads the JSON config and runs the Uvicorn app with host/port overrides
- expose a `foldermate` console script via `pyproject.toml` so Windows installs get a launcher
- update the README with the new command usage and default local URL

## Testing
- pylint foldermate
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2d0987f348320be44a71ff3c11d75